### PR TITLE
Lock connection while in use

### DIFF
--- a/lib/DBDish/ErrorHandling.pm6
+++ b/lib/DBDish/ErrorHandling.pm6
@@ -22,6 +22,10 @@ package X::DBDish {
     class ConnectionFailed is DBError {
         has $.why = "Can't connect";
     }
+
+    class ConnectionInUse is DBError {
+        has $.why = 'Unsupported Concurrency';
+    }
 }
 
 role DBDish::ErrorHandling is export {
@@ -62,8 +66,8 @@ role DBDish::ErrorHandling is export {
         $!RaiseError and .throw or .fail;
     }
 
-    method !set-err(Int $code, Str $errstr) is hidden-from-backtrace {
-        self!error-dispatch: X::DBDish::DBError.new(
+    method !set-err(Int $code, Str $errstr, Str :$error-class = 'X::DBDish::DBError') is hidden-from-backtrace {
+        self!error-dispatch: ::($error-class).new(
             :$code, :native-message($errstr), :$.driver-name
         );
     }

--- a/lib/DBDish/Pg/Connection.pm6
+++ b/lib/DBDish/Pg/Connection.pm6
@@ -111,7 +111,10 @@ method commit {
         warn "Commit ineffective while AutoCommit is on";
         return;
     };
-    $!pg_conn.PQexec("COMMIT");
+
+    $!parent.protect-connection: {
+        $!pg_conn.PQexec("COMMIT");
+    };
     $.in_transaction = False;
 }
 
@@ -120,7 +123,10 @@ method rollback {
         warn "Rollback ineffective while AutoCommit is on";
         return;
     };
-    $!pg_conn.PQexec("ROLLBACK");
+
+    $!parent.protect-connection: {
+        $!pg_conn.PQexec("ROLLBACK");
+    };
     $.in_transaction = False;
 }
 

--- a/t/38-pg-connection-lock.t
+++ b/t/38-pg-connection-lock.t
@@ -1,0 +1,54 @@
+v6;
+use Test;
+use DBIish;
+
+plan 3;
+
+my %con-parms;
+
+# If env var set, no parameter needed.
+%con-parms<dbname> = 'dbdishtest' unless %*ENV<PGDATABASE>;
+%con-parms<user> = 'postgres' unless %*ENV<PGUSER>;
+%con-parms<port> = 5432;
+# Test for issue #62
+
+my $dbh;
+
+try {
+    $dbh = DBIish.connect('Pg', |%con-parms);
+    CATCH {
+        when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+            diag "$_\nCan't continue.";
+        }
+        default { .throw; }
+    }
+}
+without $dbh {
+    skip-rest 'prerequisites failed';
+    exit;
+}
+
+# Use the connection for some activity
+my $sth = $dbh.prepare('SELECT pg_sleep(0.4)');
+my $p1 = start {
+    $sth.execute();
+}
+
+# Ensure the query is running
+sleep 0.2;
+
+throws-like {
+    $sth.execute();
+}, X::DBDish::ConnectionInUse, 'Connection used by multiple threads', message => /"multiple threads"/;
+
+await $p1;
+
+# Test for query success
+lives-ok {
+    my $sth-select = $dbh.prepare('SELECT 1 AS value');
+    $sth-select.execute();
+    my $row = $sth-select.row(:hash);
+    is($row<value>, 1, 'Query returned a result');
+}, 'DB Connection uncorrupted';
+
+done-testing;


### PR DESCRIPTION
A generic lock/unlock (via atomics) has been provided for all database types (this is documented issue on MySQL, SQLite, and Oracle too) but I don't see an obvious generic way to implement it on everything at an upper level. The success case would be straight forward in DBDish::StatementHandle but different implementations make unlocking trickier. Also some variance by driver (Pg needs a lock on prepare because it hits the server, SQLite doesn't).

Implement on PostgreSQL to protect against corrupting the database connection which the test demonstrates without this patch.

I opted to use atomics to ensure high performance for rapidfire sub-millisecond queries often seen with sqlite. The other option is Lock::Async, but I believe multiple threads sharing a single active DB connection is almost never going to be intentional and it's heavy in the rapidfire case. If nothing else multi-thread single-connection makes DB transaction semantics quite tricky.

Lock isn't really an option as there may be dozens of in-flight multi-minute (or even multi-hour) queries.

If multi-thread single-connection is common, we might have a mode-switch for the locking mechanism or enable a separate promise