### PR TITLE
Add basic Connection Pool ability

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,6 +10,7 @@
         "DBIish"                    : "lib/DBIish.pm6",
         "DBIish::Common"            : "lib/DBIish/Common.pm6",
         "DBIish::CommonTesting"     : "lib/DBIish/CommonTesting.pm6",
+        "DBIish::Pool"              : "lib/DBIish/Pool.pm6",
         "DBDish"                    : "lib/DBDish.pm6",
         "DBDish::Connection"        : "lib/DBDish/Connection.pm6",
         "DBDish::ErrorHandling"     : "lib/DBDish/ErrorHandling.pm6",

--- a/README.pod
+++ b/README.pod
@@ -115,6 +115,49 @@ Example:
     my @data = $sth.allrows(:array-of-hash); # [ ( a => 1, b => 'val1'), ( a => 3, b => 'val2') ]
     my %data = $sth.allrows(:hash-of-array); # a => [1, 3], b => ['val1', 'val2']
 
+=head2 Connection Pooling
+
+Connection pooling is supported for PostgreSQL databases. This can significantly improve performance when
+overhead from establishing a connection is a significant portion of the work such as a database server on a
+distant network or when a connection is created for a very short query.
+
+To use, create a pool, then take a connection from that pool. The connection is returned to the pool when
+dispose is called. Calling dispose is important as otherwise you may exhaust the pool due to garbage collection
+being unpredictable.
+
+See your database driver for a description of the connection parameters allowed. These are the same as the
+C<connect> call.
+
+    my $pool = DBH.pool('Pg', $initial-size = 1, :$max-connections = 10, :$min-spare-connections = 1,
+                       :$max-idle-duration = Duration.new(60), Code :$!connection-scrub, |%connection-parameters);
+    my $dbh = $pool.connect();
+
+    $dbh.do({SELECT 1});
+
+    $dbh.dispose;
+
+The connection pooler will attempt to keep C<min-spare-connections> available for use. For busy multi-threaded daemons,
+this should be raised from 1.
+
+Once C<max-connections> is reached, C<connect()> will wait for a connection to become available before returning.
+You may request that C<connect()> return a promise instead of waiting internally.
+
+    my $dbh = await $pool.connect(:async);
+
+=head3 stats
+
+A small Hash with pool connection statistics is available.
+
+   my %stats = $pool.stats();
+
+Statistics fields include:
+  * inuse ➡ Number of connections currently in use
+  * idle ➡ Number available for immediate use.
+  * starting ➡ Number starting up
+  * scrub ➡ Numbers recently disposed, currently being scrubbed
+  * total ➡ Total of the C<inuse>, C<idle>, C<starting>, and C<scrub> counters. Due to a few very short race conditions, this may not add up at times.
+  * waiting ➡ Number of unfilled C<connect> calls.
+
 =head1 INSTALLATION
 
     $ zef install DBIish

--- a/lib/DBIish/Pool.pm6
+++ b/lib/DBIish/Pool.pm6
@@ -1,0 +1,248 @@
+
+unit class DBIish::Pool;
+
+has Int $.initial-size where ($_ >= 1);
+has Int $.max-connections where ($_ >= 0);
+has Int $.min-spare-connections where ($_ >= 0);
+
+has Duration $.max-idle-duration;
+has $!connection-scrub;
+
+has $!driver;
+has %!connection-args;
+
+# Connections being started.
+has atomicint $!starting-count = 0;
+
+# Connections wanted.
+has atomicint $!waiting-count = 0;
+
+# Connections reserved for use until .dispose is called.
+has atomicint $!inuse-count = 0;
+
+# Connections being scrubbed between users.
+# A large positive number may indicate poor performance with the scrub function.
+has atomicint $!scrub-count = 0;
+
+# Size of connection-queue
+has atomicint $!idle-count = 0;
+
+# Smallest number of idle connections seen in the queue. This is a best effort for queue maintenance and
+# not necessarily an exact number. Performance handing out connections is more important than an exact count as a
+# very busy pool is far less likely to need to terminate excess connections.
+has atomicint $!min-idle-since-last-check = 0;
+
+# Queue of connections ready for use.
+has Channel $!connection-queue .= new;
+
+has Bool $!terminate-pool = False;
+
+# Override the connection dispose function to enable connection reuse.
+role Pooled {
+    has DBIish::Pool $.connection-pool is rw;
+    has Bool $.pool-dispose is rw;
+
+    method dispose() {
+        self.teardown-connection();
+
+        return $.connection-pool.reuse-connection(self);
+    }
+
+    # Warn if the connection was DESTROYed prior to pool termination. This indicates that the connection
+    # went out of scope.
+    submethod DESTROY() {
+        $!connection-pool.dispose-connection();
+    }
+}
+
+submethod BUILD(:$!driver, :$!initial-size = 1, :$!max-connections = 10, :$!min-spare-connections = 1, :$!max-idle-duration = Duration.new(60),
+        Code :$!connection-scrub, *%!connection-args) { }
+
+# Change to Lock::Async in the future once commonly available.
+my Lock $new-connection-lock .= new;
+submethod TWEAK() {
+    start {
+        # Build initial-size connections in the background. Wait a short amount of time for the
+        # pool class to be fully initialized by the previous thread.
+        await Promise.in(0.1);
+
+        # Startup initial-size number of connections.
+        $new-connection-lock.protect: {
+            for ^$!initial-size {
+                self!start-single-connection();
+            }
+        }
+
+        # Terminate excess connections. This is based on the size of the pool and not use
+        # of a particular connection as the pool rotates connection usage.
+        until $!terminate-pool {
+            await Promise.in($!max-idle-duration);
+
+            my $kill-count = $!min-idle-since-last-check - $!min-spare-connections;
+            for ^$kill-count {
+                my $dbh = $!connection-queue.poll();
+                if ($dbh) {
+                    $!idle-count ⚛-= 1;
+                    $dbh._disconnect;
+                }
+            }
+
+            # Reset to the current idle connection count.
+            $!min-idle-since-last-check ⚛= $!idle-count;
+        }
+    }
+}
+
+# Injects connections  when required. Attempts to fulfill waiting-count and ensure
+# there are spares available.
+method !inject-connections() {
+    # Protect against a connection creation storm via multiple threads. Restrict to one new connection at a time.
+    $new-connection-lock.protect: {
+
+        # Start enough to fulfill all waiting and spare slots provided it doesn't go beyond max-connections.
+        while ($!waiting-count > 0 or $!idle-count < $!min-spare-connections) and self!total-connections < $.max-connections {
+            self!start-single-connection();
+        }
+    }
+}
+
+method !start-single-connection() {
+    $!starting-count ⚛+= 1;
+    my $connection = $!driver.connect(|%!connection-args);
+    $!idle-count ⚛+= 1;
+    $!starting-count ⚛-= 1;
+
+    $!connection-queue.send($connection);
+}
+
+method !get-one-connection() {
+    $!waiting-count ⚛+= 1;
+
+    # Poll from the queue until a valid connection is found.
+    my $dbh;
+    while (not $dbh) {
+        $dbh = $!connection-queue.poll();
+        if ($dbh) {
+            $!inuse-count ⚛+= 1;
+            $!idle-count ⚛-= 1;
+            $!min-idle-since-last-check ⚛= $!idle-count if ($!min-idle-since-last-check > $!idle-count);
+        }
+        else {
+            # Start a new connection if the limit hasn't been reached. inject-connections also checks
+            # this limit but preventing the start block from firing is useful on heavily loaded systems.
+            if ($.max-connections > self!total-connections) {
+                start {
+                    self!inject-connections();
+                }
+            }
+
+            # If poll wasn't successful, wait more aggressively. Either a new connection is starting or
+            # the queue has reached the maximum size.
+            $dbh = $!connection-queue.receive();
+            $!inuse-count ⚛+= 1;
+            $!idle-count ⚛-= 1;
+            $!min-idle-since-last-check ⚛= $!idle-count if ($!min-idle-since-last-check > $!idle-count);
+        }
+
+        # Check the state of the connection and try the entire process again if it isn't active.
+        # Dispose callback takes care to not re-add dead connections back to the pool.
+        unless $dbh.ping {
+            # Not taking this connection. Back out the earlier increment.
+            $!inuse-count ⚛-= 1;
+
+            $dbh.dispose;
+            $dbh = Nil;
+        }
+    }
+
+    $!waiting-count ⚛-= 1;
+
+    # Override the default connection dispose function
+    $dbh = $dbh but Pooled;
+    # Setup a reference to this pool. It's possible a user has multiple pools active.
+    $dbh.connection-pool = self;
+
+    return $dbh;
+}
+
+multi method connect() is default {
+    return self!get-one-connection();
+}
+
+multi method connect(Bool :$async! where ($_) --> Promise) {
+    my $connection-promise = Promise.new();
+    my $v = $connection-promise.vow();
+
+    start {
+        $v.keep(self!get-one-connection());
+    }
+
+    return $connection-promise;
+}
+
+# Due to the use of atomics rather than Lock, these stats will typically be correct but occasionally there
+# is a small risk of an off-by-one error.
+method stats() {
+    {
+        inuse => $!inuse-count,
+        idle => $!idle-count,
+        starting => $!starting-count,
+        scrub => $!scrub-count,
+        total => self!total-connections,
+        waiting => $!waiting-count,
+    }
+}
+
+method !total-connections( --> Int ) {
+    $!idle-count + $!starting-count + $!inuse-count + $!scrub-count;
+}
+
+method dispose() {
+    $!terminate-pool = True;
+
+    # Empty the Channel.
+    my $dbh;
+    repeat while ($dbh) {
+        $dbh = $!connection-queue.poll();
+        $dbh.dispose with $dbh;
+    }
+}
+
+method dispose-connection {
+    # If a connection was disposed of before pool termination then it should be removed from the inuse tracker and
+    # the user notified that what they've done is inefficient
+    unless $!terminate-pool {
+        $!inuse-count ⚛-= 1;
+        warn 'Connection DESTROY without dispose() call. Connection cannot be reused in the pool';
+    }
+}
+
+method reuse-connection($connection --> Bool) {
+    $!scrub-count ⚛+= 1;
+    $!inuse-count ⚛-= 1;
+
+    # Connection or pool is dead. Let be disconnected.
+    if (not $connection.ping or $!terminate-pool) {
+        $!scrub-count ⚛-= 1;
+        return True;
+    }
+
+    # Start a new thread to scrub the connection so the caller
+    # can continue doing real work.
+    start {
+        # Scrub connection using the user-provided function or
+        # using the driver default function.
+        with $!connection-scrub {
+            $!connection-scrub($connection);
+        } else {
+            $connection.scrub-state-for-reuse();
+        }
+
+        $!idle-count ⚛+= 1;
+        $!scrub-count ⚛-= 1;
+        $!connection-queue.send($connection);
+    }
+
+    return False;
+}
+

--- a/t/38-pg-pool.t
+++ b/t/38-pg-pool.t
@@ -1,0 +1,158 @@
+use v6;
+use Test;
+use DBIish;
+
+plan 3;
+
+my %con-parms;
+
+# If env var set, no parameter needed.
+%con-parms<dbname> = 'dbdishtest' unless %*ENV<PGDATABASE>;
+%con-parms<user> = 'postgres' unless %*ENV<PGUSER>;
+%con-parms<port> = 5432;
+
+# Test connection
+my $dbh;
+try {
+    $dbh = DBIish.connect('Pg', |%con-parms);
+    $dbh.dispose;
+    CATCH {
+        when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+            diag "$_\nCan't continue.";
+        }
+        default { .throw; }
+    }
+}
+without $dbh {
+    skip-rest 'prerequisites failed';
+    exit;
+}
+
+
+my constant MAX_CONNECTIONS = 3;
+my constant INITIAL_SIZE = 2;
+
+my $pool = DBIish.pool('Pg', initial-size => INITIAL_SIZE, min-spare-connections => 1, max-connections => MAX_CONNECTIONS, |%con-parms);
+
+# Let the pool initialize
+await Promise.in(1);
+
+subtest {
+    $dbh = $pool.connect();
+
+    # Confirm it's a real DBH
+    my $sth = $dbh.prepare(q{SELECT 1 + 1 AS result});
+    $sth.execute();
+    my $row = $sth.row(:hash);
+    is $row<result>, 2, 'Has a live connection';
+
+    my $stats = $pool.stats;
+    is $stats<total>, INITIAL_SIZE, 'Initial-size of connections';
+    is $stats<starting>, 0, 'Connections all started';
+    is $stats<inuse>, 1, 'Single connection in-use';
+    is $stats<scrub>, 0, 'No connections being scrubbed';
+    is $stats<idle>, INITIAL_SIZE - 1, 'Count Idle connections';
+}, 'Initialize';
+
+subtest {
+    $dbh.dispose;
+
+    my $stats = $pool.stats;
+    is $stats<total>, INITIAL_SIZE, '%d connections'.sprintf(INITIAL_SIZE);
+    is $stats<inuse>, 0, 'No connections in use';
+}, 'Dispose';
+
+subtest {
+    my @connections;
+    for ^MAX_CONNECTIONS {
+        my $dbh = $pool.connect;
+        @connections.push($dbh);
+    }
+    my $stats = $pool.stats;
+    is $stats<total>, MAX_CONNECTIONS, 'Connection Limit';
+
+    # Connect waits
+    my $timed-out = True;
+    my $wait-conn;
+    my $p = start {
+        $wait-conn = $pool.connect();
+        $timed-out = False;
+    };
+    await Promise.anyof($p, Promise.in(1));
+    ok !$wait-conn.defined, 'Connection not created';
+    ok $timed-out, 'Connect waits after hitting Max Connections';
+
+
+    # Thread eventually finishes
+    @connections.pop.dispose;
+    await Promise.anyof($p, Promise.in(1));
+    ok $wait-conn.defined, 'Connection eventually obtained';
+    ok !$timed-out, 'Connect obtained, clear timeout';
+
+    # Async connect gives results when it can.
+    my $pconn1 = $pool.connect(:async);
+    my $pconn2 = $pool.connect(:async);
+    is $pconn1.status, Planned, 'Async 1 is pending';
+    is $pconn2.status, Planned, 'Async 2 is pending';
+
+    # Dispose of connection. After a bit of time to refresh, conn1 should
+    # have a connection.
+    $wait-conn.dispose;
+    await Promise.anyof($pconn1, Promise.in(5));
+    is $pconn1.status, Kept, 'Asynce 1 has connection';
+    is $pconn2.status, Planned, 'Async 2 is still pending';
+
+    $stats = $pool.stats;
+    is $stats<total>, MAX_CONNECTIONS, 'Connection Limit';
+
+    my $connection;
+    $p = start {
+        $pool.connect();
+    }
+    await Promise.anyof($p, Promise.in(2));
+    ok not $connection.defined, 'Connect() blocked at limit';
+}, 'Connect blocks at limit';
+
+#`[[
+
+# Purposfully hold off connecting until mutiple threads are running. This trips up the driver
+# loading mechanism in a way that 43-sqlite-threads.t misses.
+
+my $skip-tests = False;
+my @promises = do for ^5 -> $thread {
+    start {
+        my $dbh;
+        try {
+            $dbh = DBIish.connect('Pg', |%con-parms);
+            CATCH {
+                when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+                    diag "$_\nCan't continue.";
+                }
+                default { .rethrow; }
+            }
+        }
+        # Skip work if there is no connection
+        if $dbh {
+            # Keep queries active by having them in sleep
+            my $sth = $dbh.prepare('SELECT pg_sleep(0.3)');
+            for ^4 {
+                $sth.execute();
+            }
+            $sth.finish;
+            $dbh.dispose;
+        } else {
+            $skip-tests = True;
+        }
+    }
+}
+await @promises;
+
+if ($skip-tests) {
+    skip-rest 'prerequisites failed';
+} else {
+    pass 'Pass multithread multiconnection survival test';
+}
+
+]]
+
+done-testing;


### PR DESCRIPTION
Currently supports PostgreSQL only. Other drivers like MySQL or Oracle need to accept dispose-callback and add a scrub-state-for-reuse() function which resets the connection state. I don't believe there would be a benefit for SQLite.

This is implemented as a Channel for the queue of connections with a few atomic counters to assist in counting the number of active database connections and their state. The connection itself is exactly what you would get from DBIish.connect() aside from the addition of a dispose-callback hook.

The pool has an initial size, an idle timeout, and enforces max-connections. At max-connections $pool.connect will wait until a currently in-use connection becomes available. A max work-load is typically useful to prevent overloading the database.

Typical use looks like this, where the connection arguments are passed to the driver specified.

    my $pool = DBIish.pool('Pg', max-connections => 10, |%conn);
    my $dbh = $pool.connect()
    # DO WORK
    $dbh.dispose;

For Pg, execution time for 20_000 connect/SELECT 1/disconnect loops is reduced from 23 seconds to 5 seconds for a database on localhost. This difference would be quite a bit higher for a networked database.