### PR TITLE
Correct for unquoted non-word characters

### DIFF
--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -125,7 +125,7 @@ my grammar PgArrayGrammar {
     token null       { 'NULL' }
     # Quoted strings may contain any byte sequence except a null. Characters like " and \
     # are escaped by a \ and must be unescaped (\" => ", \\ => \)
-    rule string      { '"' $<value>=( [<-[\\"]>||'\"'||'\\\\']* ) '"' || $<value>=( \w+ ) }
+    rule string      { '"' $<value>=( [<-[\\"]>||'\"'||'\\\\']* ) '"' || $<value>=( <-["{}]>+ ) }
 };
 
 sub _to-type($value, Mu:U $type) {


### PR DESCRIPTION
Values such as ARRAY['foo=bar'] failed to be parsed correctly.