### PR TITLE
F.mariadb

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -39,6 +39,7 @@
     "source-url" : "git://github.com/perl6/DBIish.git",
     "tags": [
       "database",
+      "mariadb",
       "mysql",
       "oracle",
       "postgres",

--- a/t/28-mysql-connection-lock.t
+++ b/t/28-mysql-connection-lock.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+use DBIish;
+
+plan 3;
+
+my %con-parms = :database<dbdishtest>, :user<testuser>, :password<testpass>;
+my $dbh;
+
+try {
+    $dbh = DBIish.connect('mysql', |%con-parms);
+    CATCH {
+        when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+            diag "$_\nCan't continue.";
+        }
+        default { .throw; }
+    }
+}
+without $dbh {
+    skip-rest 'prerequisites failed';
+    exit;
+}
+
+# Use the connection for some activity
+my $sth = $dbh.prepare('SELECT sleep(1)');
+my $p1 = start {
+    $sth.execute();
+}
+
+# Ensure the query is running
+sleep 0.2;
+
+throws-like {
+    $sth.execute();
+}, X::DBDish::ConnectionInUse, 'Connection used by multiple threads', message => /"multiple threads"/;
+
+await $p1;
+
+# Test for query success
+lives-ok {
+    my $sth-select = $dbh.prepare('SELECT 1 AS value');
+    $sth-select.execute();
+    my $row = $sth-select.row(:hash);
+    is($row<value>, 1, 'Query returned a result');
+}, 'DB Connection uncorrupted';
+
+done-testing;

--- a/t/28-mysql-threads.t
+++ b/t/28-mysql-threads.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+use DBIish;
+
+plan 1;
+
+my %con-parms = :database<dbdishtest>, :user<testuser>, :password<testpass>;
+my $dbh;
+
+try {
+    $dbh = DBIish.connect('mysql', |%con-parms);
+    CATCH {
+        when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+            diag "$_\nCan't continue.";
+        }
+        default { .throw; }
+    }
+}
+without $dbh {
+    skip-rest 'prerequisites failed';
+    exit;
+}
+
+# Connection tested. Each thread is expected to get it's own connection
+$dbh.dispose;
+
+my $skip-tests = False;
+my @promises = do for ^5 -> $thread {
+    start {
+        my $dbh = DBIish.connect('mysql', |%con-parms);
+
+            # Keep queries active by having them in sleep
+            my $sth = $dbh.prepare('SELECT sleep(1)');
+            for ^4 {
+                $sth.execute();
+            }
+            $sth.finish;
+            $dbh.dispose;
+    }
+}
+await @promises;
+
+pass 'Pass multithread multiconnection survival test';
+
+


### PR DESCRIPTION
Bring MariaDB/Mysql up to par with the Pg driver for threading issues.

I believe #90 and #117 may both be closed. #117 was probably related to NativeCall fixes in MoarVM late during 2019.

#129 is still relevant for Oracle.
