### PR TITLE
Replace old "nom" with newer static build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
 
 perl6:
     - 2017.09
+    - 2019.11
     - latest
-    - nom
 sudo: false
 install:
     - rakudobrew build-zef && zef -v install .


### PR DESCRIPTION
Nom was the old name for master and was stuck at:
  This is Rakudo version 2017.10-4-g4fca94743 built on MoarVM version 2017.10

Replace it with 2019.11 which has several NativeCall and threading fixes.

"latest" already builds "master".