### PR TITLE
Unbreak error handling regexes

### DIFF
--- a/lib/DBDish/Pg/ErrorHandling.pm6
+++ b/lib/DBDish/Pg/ErrorHandling.pm6
@@ -79,7 +79,7 @@ package X::DBDish {
         #  - Class 57\w{3}: Operator Intervention (early/forced connection termination)
         #  - 72000 snapshot_too_old
         method is-temporary {
-           so $.sqlstate ~~ /^ '08'<[alnum]> ** 3 | '40001'| '40P01' | '57'<[alnum]> ** 3 | '72000' $/;
+           so $.sqlstate ~~ /^ '08'<alnum> ** 3 | '40001'| '40P01' | '57'<alnum> ** 3 | '72000' $/;
         }
     }
 }


### PR DESCRIPTION
In 87020e0e I was mistaken on how to use character classes. Fix that.