### PR TITLE
F.array fix

### DIFF
--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -121,16 +121,16 @@ method _row() {
 }
 
 my grammar PgArrayGrammar {
-    rule array       { '{' (<element> ','?)* '}' }
     rule TOP         { ^ <array> $ }
-    rule element     { <array> | <float> | <integer> | <null> | <string> }
-    token float      { (\d+ '.' \d+ | \d '.' \d+ 'e+' \d+) }
-    token integer    { (\d+) }
+    rule array       { '{' ( <element> ','?)* '}' }
+    rule element     { <array> | <quoted-string> | <null> | <unquoted-string>}
 
-    token null       { 'NULL' }
     # Quoted strings may contain any byte sequence except a null. Characters like " and \
     # are escaped by a \ and must be unescaped (\" => ", \\ => \)
-    rule string      { '"' $<value>=( [<-[\\"]>||'\"'||'\\\\']* ) '"' || $<value>=( <-["{}]>+ ) }
+    rule quoted-string   { '"' $<value>=( [<-[\\"]>||'\"'||'\\\\']* ) '"' }
+    rule null            { "NULL" }
+    rule unquoted-string { <-["{},]>+ }
+
 };
 
 sub _to-type($value, Mu:U $type) {
@@ -147,20 +147,37 @@ sub _to-array(Match $match, Mu:U $type) {
     for $match.<array>.values -> $element {
         if $element.values[0]<array>.defined { # An array
             if $clean && $arr.of === $type { # Need to downgrade
-                $arr = Array.new; $clean = False;
+                $arr = Array.new;
+                $clean = False;
             }
             $arr.push: @(_to-array($element.values[0], $type));
-        } elsif $element.values[0]<float>.defined { # Floating point number
-            $arr.push: $type($element.values[0]<float>);
-        } elsif $element.values[0]<integer>.defined { # Integer
-            $arr.push: $type($element.values[0]<integer>);
-        } elsif $element.values[0]<null>.defined { # Null string
-            $arr.push: Nil;
-        } else { # Must be a String
-            my $val = ~$element.values[0]<string><value>;
+        } elsif $element.values[0]<quoted-string>.defined {
+            my $val = ~$element.values[0]<quoted-string><value>;
+
+            # Remove escape sequences
             $val ~~ s|'\\"'|"|;
             $val ~~ s|'\\\\'|\\|;
+
             $arr.push: $val;
+        } elsif $element.values[0]<null>.defined {
+            $arr.push: Nil;
+        } else {
+            # An unquoted string could be a number of different datatypes. These
+            # are difficult to put into the Grammar without enabling
+            # backtracking due to values like '123:123' matching part of the integer
+            # block.
+            given ~$element.values[0]<unquoted-string> {
+                when /^(\d+ '.' \d+ | \d '.' \d+ 'e+' \d+)$/ {
+                    $arr.push: $type($_);
+                }
+                when /^(\d+)$/ {
+                    $arr.push: $type($_);
+                }
+                default {
+                    my $val = $_;
+                    $arr.push: $val;
+                }
+            }
         }
     }
     $arr;

--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -158,26 +158,12 @@ sub _to-array(Match $match, Mu:U $type) {
             $val ~~ s|'\\"'|"|;
             $val ~~ s|'\\\\'|\\|;
 
-            $arr.push: $val;
+            $arr.push: $type($val);
         } elsif $element.values[0]<null>.defined {
             $arr.push: Nil;
         } else {
-            # An unquoted string could be a number of different datatypes. These
-            # are difficult to put into the Grammar without enabling
-            # backtracking due to values like '123:123' matching part of the integer
-            # block.
-            given ~$element.values[0]<unquoted-string> {
-                when /^(\d+ '.' \d+ | \d '.' \d+ 'e+' \d+)$/ {
-                    $arr.push: $type($_);
-                }
-                when /^(\d+)$/ {
-                    $arr.push: $type($_);
-                }
-                default {
-                    my $val = $_;
-                    $arr.push: $val;
-                }
-            }
+            # Every element will be of the expected datatype.
+            $arr.push: $type(~$element.values[0]<unquoted-string>);
         }
     }
     $arr;

--- a/t/36-pg-array.t
+++ b/t/36-pg-array.t
@@ -4,7 +4,7 @@ use v6;
 use DBIish;
 use Test;
 
-plan 30;
+plan 33;
 my %con-parms;
 # If env var set, no parameter needed.
 %con-parms<database> = 'dbdishtest' unless %*ENV<PGDATABASE>;
@@ -97,6 +97,17 @@ isa-ok $obj.schedule[0], Array[Str];
     is $col1.elems, 1,    '1 element';
     is $col1[0], '1.2e+33', 'Big Float Value';
     is $col1[0].^name, 'Num', 'Is Number';
+}
+
+# Number with text
+{
+    $sth = $dbh.prepare(q{select ARRAY['14:00:2b:01:02:03:04:05']::text[]});
+    $sth.execute();
+
+    my ($col1) = $sth.row;
+    is $col1.elems, 1,    '1 element';
+    is $col1[0], '14:00:2b:01:02:03:04:05', 'Mac in text';
+    is $col1[0].^name, 'Str', 'Is String';
 }
 
 # Text can be anything except a null. With different encodings, every byte combination is possible.


### PR DESCRIPTION
Commit 1 fixes strings with mixed values without requiring backtracking.

This SQL array with a single element:
ARRAY['12:34:56:78']

Was being interpreted by Raku as:
['12', ':34:56:78']


Commit 2 removes a chunk of code and makes it faster than the original for large simple arrays. It does this by relying on the %oid-to-type parameter.