### PR TITLE
Mark legacy functions deprecated

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -361,6 +361,11 @@ These will be removed on June 2022.
 * $sth.fetch() deprecated in favour of $sth.row()
 * $sth.fetchall_arrayref() deprecated in favour of $sth.allrows(:array-of-hash)
 
+* $sth.mysql_insertid deprecated in favour of $sth.insert-id
+* $dbh.mysql_insertid deprecated in favour of $dbh.insert-id
+* $dbh.disconnect deprecated in favour of $sth.dispose
+* $dbh.install_driver deprecated in favour of $sth.install-driver
+
 =head1 SEE ALSO
 
 The Perl 6 Pod in the L<doc:DBIish> module.

--- a/README.pod
+++ b/README.pod
@@ -366,6 +366,12 @@ These will be removed on June 2022.
 * $dbh.disconnect deprecated in favour of $sth.dispose
 * $dbh.install_driver deprecated in favour of $sth.install-driver
 
+* $dbh.selectrow_arrayref deprecated in favor of $sth = $dbh.prepare.execute(); $sth.row
+* $dbh.selectrow_hashref deprecated in favor of $sth = $dbh.prepare.execute(); $sth.row(:hash)
+* $dbh.selectall_arrayref deprecated in favor of $sth = $dbh.prepare.execute(); $sth.allrows
+* $dbh.selectall_hashref deprecated in favor of $sth = $dbh.prepare.execute(); $sth.allrows(:array-of-hashes)
+* $dbh.selectcol_arrayref deprecated in favor of $sth = $dbh.prepare.execute(); $sth.allrows(:array-of-hashes)
+
 =head1 SEE ALSO
 
 The Perl 6 Pod in the L<doc:DBIish> module.

--- a/README.pod
+++ b/README.pod
@@ -346,6 +346,20 @@ Attract more contributors.
 Integrate with the DBDI project (L<http://github.com/timbunce/DBDI>)
 once it has sufficient functionality.
 
+=head1 DEPRECATED
+
+These will be removed on June 2022.
+
+* $sth.fetchrow() deprecated in favour of $sth.row()
+* $sth.fetchrow_hashref() deprecated in favour of $sth.row(:hash)
+* $sth.fetchall_hashref() deprecated in favour of $sth.allrows(:hash-of-arrays)
+* $sth.fetchall-hash() deprecated in favour of $sth.allrows(:hash-of-arrays)
+* $sth.fetchall-AoH() deprecated in favour of $sth.allrows(:array-of-hash)
+* $sth.fetchrow_array() deprecated in favour of $sth.row()
+* $sth.fetchrow_hashref() deprecated in favour of $sth.row(:hash)
+* $sth.fetchrow_arrayref() deprecated in favour of $sth.row(:hash)
+* $sth.fetch() deprecated in favour of $sth.row()
+* $sth.fetchall_arrayref() deprecated in favour of $sth.allrows(:array-of-hash)
 
 =head1 SEE ALSO
 

--- a/lib/DBDish/Pg/Connection.pm6
+++ b/lib/DBDish/Pg/Connection.pm6
@@ -60,7 +60,7 @@ method server-version() {
     $ = Version.new($!pg_conn.pg-parameter-status('server_version'));
 }
 
-method selectrow_arrayref(Str $statement, $attr?, *@bind is copy) {
+method selectrow_arrayref(Str $statement, $attr?, *@bind is copy) is DEPRECATED('prepare/execute/row') {
     with self.prepare($statement, $attr) {
         .execute(@bind) and .fetchrow_arrayref;
     } else {
@@ -68,7 +68,7 @@ method selectrow_arrayref(Str $statement, $attr?, *@bind is copy) {
     }
 }
 
-method selectrow_hashref(Str $statement, $attr?, *@bind is copy) {
+method selectrow_hashref(Str $statement, $attr?, *@bind is copy) is DEPRECATED('prepare/execute/row(:hash)') {
     with self.prepare($statement, $attr) {
         .execute(@bind) and .fetchrow_hashref;
     } else {
@@ -76,7 +76,7 @@ method selectrow_hashref(Str $statement, $attr?, *@bind is copy) {
     }
 }
 
-method selectall_arrayref(Str $statement, $attr?, *@bind is copy) {
+method selectall_arrayref(Str $statement, $attr?, *@bind is copy) is DEPRECATED('prepare/execute/allrows()') {
     with self.prepare($statement, $attr) {
         .execute(@bind) and .fetchall_arrayref;
     } else {
@@ -84,7 +84,7 @@ method selectall_arrayref(Str $statement, $attr?, *@bind is copy) {
     }
 }
 
-method selectall_hashref(Str $statement, Str $key, $attr?, *@bind is copy) {
+method selectall_hashref(Str $statement, Str $key, $attr?, *@bind is copy) is DEPRECATED('prepare/execute/allrows(:array-of-hash)') {
     with self.prepare($statement, $attr) {
         .execute(@bind) and .fetchall_hashref($key);
     } else {
@@ -92,7 +92,7 @@ method selectall_hashref(Str $statement, Str $key, $attr?, *@bind is copy) {
     }
 }
 
-method selectcol_arrayref(Str $statement, $attr?, *@bind is copy) {
+method selectcol_arrayref(Str $statement, $attr?, *@bind is copy) is DEPRECATED('prepare/execute/allrows') {
     with self.prepare($statement, $attr) {
         .execute(@bind) and do {
             my @results;

--- a/lib/DBDish/StatementHandle.pm6
+++ b/lib/DBDish/StatementHandle.pm6
@@ -134,18 +134,18 @@ multi method allrows() {
 }
 
 # Legacy
-method fetchrow {
+method fetchrow is DEPRECATED('row()') {
     if my \r = self._row {
         my @ = (r.map: { .defined ?? ~$_ !! Str });
     } else { @ };
 }
 
-method fetchrow-hash {
+method fetchrow-hash is DEPRECATED('row(:hash)') {
     hash @!column-name Z=> self.fetchrow;
 }
-method fetchrow_hashref { self.fetchrow-hash }
+method fetchrow_hashref is DEPRECATED('row(:hash)'){ self.fetchrow-hash }
 
-method fetchall_hashref(Str $key) {
+method fetchall_hashref(Str $key) is DEPRECATED('allrows(:hash-of-arrays)') {
     my %results;
     while self.fetch-hash -> \h {
         %results{h{$key}} = h;
@@ -153,7 +153,7 @@ method fetchall_hashref(Str $key) {
     %results;
 }
 
-method fetchall-hash {
+method fetchall-hash is DEPRECATED('allrows(:hash-of-arrays)') {
     my @names := @!column-name;
     my %res = @names Z=> [] xx *;
     for self.fetchall-array -> @a {
@@ -164,7 +164,7 @@ method fetchall-hash {
     %res;
 }
 
-method fetchall-AoH {
+method fetchall-AoH is DEPRECATED('allrows(:array-of-hash)') {
     (0 xx *).flatmap({
         my $h = self.fetchrow-hash;
         last unless $h;
@@ -172,7 +172,7 @@ method fetchall-AoH {
     }).eager;
 }
 
-method fetchall-array {
+method fetchall-array is DEPRECATED('allrows(:array-of-hash)') {
     (0 xx *).flatmap({
         my $r = self.fetchrow;
         last unless $r;
@@ -180,8 +180,8 @@ method fetchall-array {
     }).eager;
 }
 
-method fetchrow_array { self.fetchrow }
-method fetchrow_arrayref { self.fetchrow; }
-method fetch { self.fetchrow; }
+method fetchrow_array is DEPRECATED('row(:array)') { self.fetchrow }
+method fetchrow_arrayref is DEPRECATED('row(:array)') { self.fetchrow; }
+method fetch is DEPRECATED('row()') { self.fetchrow; }
 
-method fetchall_arrayref  { [ self.fetchall-array.eager ] }
+method fetchall_arrayref is DEPRECATED('allrows(:array-of-hash)') { [ self.fetchall-array.eager ] }

--- a/t/05-mock.t
+++ b/t/05-mock.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 use DBIish;
-plan 25;
+plan 16;
 
 my $dbh = DBIish.connect('TestMock');
 my $sth = $dbh.prepare('mockdata');
@@ -20,11 +20,6 @@ nok $sth.row, 'third row is empty';
 ok $sth.Finished, 'Finished';
 
 $sth.execute;
-is $sth.fetchrow.join(','), 'a,b,1', 'first row (legacy)';
-is $sth.fetchrow.join(','), 'd,e,2', 'second row (legacy)';
-nok $sth.fetchrow, 'third row is empty (legacy)';
-
-$sth.execute;
 # Testing the internals
 my \a = $sth.allrows;
 isa-ok a, Seq, 'allrows returns Seq';
@@ -33,8 +28,6 @@ is $iter.pull-one, ['a', 'b', 1], 'A row';
 
 $sth.execute;
 is-deeply [$sth.allrows], [ ['a', 'b', 1], ['d','e', 2]], 'allrows';
-$sth.execute;
-is-deeply [$sth.fetchall-array], [ ['a', 'b', '1'], ['d', 'e', '2']], 'fetchall-array';
 
 $sth.execute;
 is-deeply $sth.row :hash, hash(col1 => 'a', col2 => 'b', colN => 1),
@@ -43,20 +36,3 @@ is-deeply $sth.row :hash, hash(col1 => 'd', col2 => 'e', colN => 2),
     'row :hash (2)';
 is-deeply $sth.row :hash, hash(), 'row :hash (empty)';
 
-$sth.execute;
-is-deeply $sth.fetchrow-hash, hash(col1 => 'a', col2 => 'b', colN => '1'),
-    'fetchrow-hash (1)';
-is-deeply $sth.fetchrow-hash, hash(col1 => 'd', col2 => 'e', colN => '2'),
-    'fetchrow-hash (2)';
-is-deeply $sth.fetchrow-hash, hash(), 'fetchrow-hash (empty)';
-
-$sth.execute;
-is-deeply $sth.fetchall-hash, hash(
-    col1 => [<a d>], col2 => [<b e>], colN => ['1', '2']
-), 'fetchall-HoA';
-
-$sth.execute;
-is-deeply $sth.fetchall-AoH, (
-    {col1 => 'a', col2 => 'b', colN => '1'},
-    {col1 => 'd', col2 => 'e', colN => '2'},
-).list, 'fetchall-AoH';

--- a/t/20-mysql.t
+++ b/t/20-mysql.t
@@ -163,7 +163,7 @@ try {
 ok defined($sth), "Prepare of select"; # test 14
 ok $sth.execute , "Execute"; # test 15
 my ($row, $errstr);
-$row = $sth.fetchrow_arrayref();
+$row = $sth.row();
 $errstr= $sth.errstr;
 nok $row, "Fetch should have failed"; # test 16
 nok $errstr, "Fetch should have failed"; # test 17
@@ -250,8 +250,8 @@ ok (my $sth2= $dbh.prepare("SELECT max(id) FROM $table")),"selectg max(id)"; # t
 ok $sth2.defined,"second prepared statement"; # test 30
 ok $sth2.execute(), "execute second prepared statement"; # test 31
 my $max_id;
-ok ($max_id= $sth2.fetch()),"fetch"; # test 32
-ok $max_id.defined,"fetch result defined"; # test 33
+ok ($max_id= $sth2.row()),"row"; # test 32
+ok $max_id.defined,"row result defined"; # test 33
 is $sth.insert-id, $max_id[0], 'sth insert id $sth.insert-id == max(id) $max_id[0] in '~$table; # test 34
 is $dbh.insert-id, $max_id[0], 'dbh insert id $dbh.insert-id == max(id) $max_id[0] in '~$table; # test 35
 ok $sth.finish(), "statement 1 finish"; #  test 36
@@ -346,8 +346,8 @@ ok( $all_ok,"insert 100 rows of random chars"); # test 48
 ok($sth = $dbh.prepare("SELECT * FROM $table LIMIT ?, ?"),"prepare of select statement with LIMIT placeholders:"); # test 49
 ok($sth.execute(20, 50),"exec of bind vars for LIMIT"); # test 50
 my ($array_ref);
-ok( (defined($array_ref = $sth.fetchall_arrayref) &&
-  (!defined($errstr = $sth.errstr) || $sth.errstr eq '')),"fetchall_arrayref"); # test 51
+ok( (defined($array_ref = $sth.allrows(:array-of-hash)) &&
+  (!defined($errstr = $sth.errstr) || $sth.errstr eq '')),"allrows"); # test 51
 is($array_ref.elems, 50,"limit 50 works"); # test 52
 
 
@@ -415,7 +415,7 @@ ok($dbh.do("CREATE TABLE t1 (id INT(4), name VARCHAR(35))"), "Creating table"); 
 ok($sth = $dbh.prepare("SHOW TABLES LIKE 't1'"),"prepare show tables"); # test 55
 ok($sth.execute(), "Executing 'show tables'"); # test 56
 my @row;
-ok((defined(@row = $sth.fetchrow_array) &&
+ok((defined(@row = $sth.row()) &&
   (!defined($errstr = $sth.errstr) || $sth.errstr eq '')),
   "Testing if result set and no errors"); # test 57
 is(@row[0], 't1', "Checking if results equal to 't1'"); # test 58
@@ -428,7 +428,7 @@ is($rows, 1, "One row should have been inserted"); # test 63
 ok($sth.finish, "Finishing up with statement handle"); # test 64
 ok($sth= $dbh.prepare("SELECT id, name FROM t1 WHERE id = 1"),"Testing prepare of query"); # test 65
 ok($sth.execute(), "Testing execute of query"); # test 66
-ok(my $ret_ref = $sth.fetchall_arrayref(),"Testing fetchall_arrayref of executed query"); # test 67
+ok(my $ret_ref = $sth.allrows(),"Testing fetchall_arrayref of executed query"); # test 67
 ok($sth= $dbh.prepare("INSERT INTO t1 values (?, ?)"),"Preparing insert, this time using placeholders"); # test 68
 %testInsertVals = ();
 $all_ok = Bool::True;
@@ -442,15 +442,15 @@ ok($all_ok, "Should have inserted one row (10 times)"); # test 69
 ok($sth.finish, "Testing closing of statement handle"); # test 70
 ok($sth= $dbh.prepare("SELECT * FROM t1 WHERE id = ? OR id = ?"),"Testing prepare of query with placeholders"); # test 71
 ok($rows = $sth.execute(1,2),"Testing execution with values id = 1 or id = 2"); # test 72
-ok($ret_ref = $sth.fetchall_arrayref(),"Testing fetchall_arrayref (should be four rows)"); # test 73
+ok($ret_ref = $sth.allrows(),"Testing fetchall_arrayref (should be four rows)"); # test 73
 is($ret_ref.elems, 4, "\$ret_ref should contain four rows in result set"); # test 74
 is($ret_ref[2][1], %testInsertVals{'1'}, "verify third row"); # test 75
 ok($sth= $dbh.prepare("DROP TABLE IF EXISTS t1"),"Testing prepare of dropping table"); # test 76
 ok($sth.execute(), "Executing drop table"); # test 77
 ok($sth= $dbh.prepare("SELECT 1"), "Prepare - Testing bug #20153"); # test 78
 ok($sth.execute(), "Execute - Testing bug #20153"); # test 79
-ok($sth.fetchrow_arrayref(), "Fetch - Testing bug #20153"); # test 80
-ok(!($sth.fetchrow_arrayref()),"Not Fetch - Testing bug #20153"); # test 81
+ok($sth.row(), "Fetch - Testing bug #20153"); # test 80
+ok(!($sth.row()),"Not Fetch - Testing bug #20153"); # test 81
 
 #-----------------------------------------------------------------------
 # from perl5 DBD/mysql/t/40bindparam.t


### PR DESCRIPTION
Any objection to marking the legacy functions as deprecated?

I believe this was discussed in #110.