### PR TITLE
Add $dbh.execute, rework $sth.execute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
     - PERL=/usr/bin/perl DBIISH_WRITE_TEST=YES
 
 perl6:
-    - 2017.09
     - 2020.01
     - latest
 sudo: false

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl"          : "6.c",
     "name"          : "DBIish",
-    "version"       : "0.6.0",
+    "version"       : "0.6.1",
     "description"   : "Database connectivity for Raku",
     "test-depends"  : [ ],
     "license"       : "BSD-2-Clause",

--- a/README.pod
+++ b/README.pod
@@ -13,11 +13,11 @@ DBIish - a simple database interface for Raku
 
     my $dbh = DBIish.connect("SQLite", :database<example-db.sqlite3>);
 
-    my $sth = $dbh.do(q:to/STATEMENT/);
+    my $sth = $dbh.execute(q:to/STATEMENT/);
         DROP TABLE IF EXISTS nom
         STATEMENT
 
-    $sth = $dbh.do(q:to/STATEMENT/);
+    $sth = $dbh.execute(q:to/STATEMENT/);
         CREATE TABLE nom (
             name        varchar(4),
             description varchar(30),
@@ -26,7 +26,7 @@ DBIish - a simple database interface for Raku
         )
         STATEMENT
 
-    $sth = $dbh.do(q:to/STATEMENT/);
+    $sth = $dbh.execute(q:to/STATEMENT/);
         INSERT INTO nom (name, description, quantity, price)
         VALUES ( 'BUBH', 'Hot beef burrito', 1, 4.95 )
         STATEMENT
@@ -39,6 +39,7 @@ DBIish - a simple database interface for Raku
     $sth.execute('TAFM', 'Mild fish taco', 1, 4.85);
     $sth.execute('BEOM', 'Medium size orange juice', 2, 1.20);
 
+    # For one-off execution
     $sth = $dbh.prepare(q:to/STATEMENT/);
         SELECT name, description, quantity, price, quantity*price AS amount
         FROM nom
@@ -50,6 +51,14 @@ DBIish - a simple database interface for Raku
     say @rows.elems; # 3
 
     $sth.dispose;
+
+    # For efficient multiple execution
+    $sth = $dbh.prepare('SELECT description FROM nom WHERE name = ?');
+    for <name1 name2> -> $name {
+        for $sth.execute($name).allrows(:array-of-hash) -> $row {
+            say $row<description>;
+        }
+    }
 
     $dbh.dispose;
 
@@ -145,12 +154,12 @@ See your PostgreSQL documentation for details.
 Pg arrays are supported when fetching array fields with C<row/allrows>. You will
 get the properly typed array according to the field type.
 
-Passing an array to C<execute/do> is now implemented. But you can also use the
+Passing an array to C<execute> is now implemented. But you can also use the
 C<pg-array-str> method on your Pg StatementHandle to convert an Array to a
 string Pg can understand:
 
-  # Insert an array via a do statement
-  my $sth = $db.do('INSERT INTO tab (array_column) VALUES ($1);', @data);
+  # Insert an array via an execute statement
+  my $sth = $db.execute('INSERT INTO tab (array_column) VALUES ($1);', @data);
 
   # Prepare an insertion of an array field
   my $sth = $db.prepare('INSERT INTO tab (array_column) VALUES ($1);');
@@ -192,7 +201,7 @@ commands in the meantime you will also need to execute C<pg-consume-input> first
 
 For example:
 
-    $db.do("LISTEN foo");
+    $db.execute("LISTEN foo");
 
     loop {
         $db.pg-consume-input
@@ -216,7 +225,7 @@ and have the following additional attributes as provided by PostgreSQL
   * type ➡ PG_DIAG_SEVERITY_NONLOCALIZED
   * type-localized ➡ PG_DIAG_SEVERITY
   * sqlstate ➡ PG_DIAG_SQLSTATE
-  * statement ➡ Statement provided to prepare() or do()
+  * statement ➡ Statement provided to prepare() or execute()
   * statement-name ➡ Statement Name provided to prepare() or created internally
   * statement-position ➡ PG_DIAG_STATEMENT_POSITION
   * internal-position ➡ PG_DIAG_INTERNAL_POSITION

--- a/examples/mysql.p6
+++ b/examples/mysql.p6
@@ -12,11 +12,11 @@ use DBIish;
 
 my $dbh = DBIish.connect("mysql", :database<test>, :user<root>, :password<sa>, :RaiseError);
 
-my $sth = $dbh.do(q:to/STATEMENT/);
+my $sth = $dbh.execute(q:to/STATEMENT/);
 	DROP TABLE IF EXISTS nom
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
 	CREATE TABLE nom (
 		name        varchar(4),
 		description varchar(30),
@@ -25,7 +25,7 @@ $sth = $dbh.do(q:to/STATEMENT/);
 	)
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
 	INSERT INTO nom (name, description, quantity, price)
 	VALUES ( 'BUBH', 'Hot beef burrito', 1, 4.95 )
 STATEMENT

--- a/examples/pg.p6
+++ b/examples/pg.p6
@@ -20,11 +20,11 @@ if $*DISTRO.is-win {
 
 my $dbh = DBIish.connect("Pg", :database<postgres>, :user<postgres>, :password<sa>, :RaiseError);
 
-my $sth = $dbh.do(q:to/STATEMENT/);
+my $sth = $dbh.execute(q:to/STATEMENT/);
 	DROP TABLE IF EXISTS nom
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
 	CREATE TABLE nom (
 		name        varchar(4),
 		description varchar(30),
@@ -33,7 +33,7 @@ $sth = $dbh.do(q:to/STATEMENT/);
 	)
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
 	INSERT INTO nom (name, description, quantity, price)
 	VALUES ( 'BUBH', 'Hot beef burrito', 1, 4.95 )
 STATEMENT

--- a/examples/pg_arrays.p6
+++ b/examples/pg_arrays.p6
@@ -25,11 +25,11 @@ my $dbh = DBIish.connect(
 	:password<sa>, :RaiseError
 );
 
-my $sth = $dbh.do(q:to/STATEMENT/);
+my $sth = $dbh.execute(q:to/STATEMENT/);
   DROP TABLE IF EXISTS sal_emp;
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
   CREATE TABLE sal_emp (
     name               text,
     pay_by_quarter     integer[],
@@ -38,7 +38,7 @@ $sth = $dbh.do(q:to/STATEMENT/);
   );
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
 	INSERT INTO sal_emp
     VALUES (
       'Bill',

--- a/examples/sqlite.p6
+++ b/examples/sqlite.p6
@@ -11,11 +11,11 @@ use DBIish;
 
 my $dbh = DBIish.connect("SQLite", :database<example-db.sqlite3>, :RaiseError);
 
-my $sth = $dbh.do(q:to/STATEMENT/);
+my $sth = $dbh.execute(q:to/STATEMENT/);
 	DROP TABLE IF EXISTS nom
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
 	CREATE TABLE nom (
 		name        varchar(4),
 		description varchar(30),
@@ -24,7 +24,7 @@ $sth = $dbh.do(q:to/STATEMENT/);
 	)
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
 	INSERT INTO nom (name, description, quantity, price)
 	VALUES ( 'BUBH', 'Hot beef burrito', 1, 4.95 )
 STATEMENT

--- a/lib/DBDish/Oracle/Connection.pm6
+++ b/lib/DBDish/Oracle/Connection.pm6
@@ -33,7 +33,7 @@ method prepare(Str $statement, :$RaiseError = $!RaiseError, *%attr) {
 }
 
 method set-defaults {
-    self.do(
+    self.execute(
 	q|ALTER SESSION SET nls_timestamp_tz_format='YYYY-MM-DD"T"HH24:MI:SS.FFTZR'|
     );
     $!last-sth-id = Nil; # Lie a little.
@@ -44,7 +44,7 @@ method commit {
         warn "Commit ineffective while AutoCommit is on";
         return;
     };
-    self.do("COMMIT");
+    self.execute("COMMIT");
     $.in_transaction = 0;
 }
 
@@ -53,7 +53,7 @@ method rollback {
         warn "Rollback ineffective while AutoCommit is on";
         return;
     };
-    self.do("ROLLBACK");
+    self.execute("ROLLBACK");
     $.in_transaction = 0;
 }
 

--- a/lib/DBDish/Oracle/StatementHandle.pm6
+++ b/lib/DBDish/Oracle/StatementHandle.pm6
@@ -91,7 +91,7 @@ method !get-meta {
     }
 }
 
-method execute(*@params) {
+method execute(*@params --> DBDish::StatementHandle) {
     self!enter-execute(@params.elems, $!param-count);
 
     # bind placeholder values

--- a/lib/DBDish/Pg/Connection.pm6
+++ b/lib/DBDish/Pg/Connection.pm6
@@ -58,12 +58,6 @@ method prepare(Str $statement, *%args) {
     }
 }
 
-method execute(Str $statement, *%args) {
-    DBDish::Pg::StatementHandle.new(
-        :$!pg_conn, :parent(self), :$statement, |%args
-    ).execute;
-}
-
 method server-version() {
     $ = Version.new($!pg_conn.pg-parameter-status('server_version'));
 }

--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -59,7 +59,7 @@ submethod BUILD(:$!parent!, :$!pg_conn!, # Per protocol
     }
 }
 
-method execute(**@params) {
+method execute(**@params --> DBDish::StatementHandle) {
     self!enter-execute(@params.elems, @!param_type.elems);
 
     $!parent.protect-connection: {

--- a/lib/DBDish/SQLite/StatementHandle.pm6
+++ b/lib/DBDish/SQLite/StatementHandle.pm6
@@ -30,7 +30,7 @@ submethod BUILD(:$!conn!, :$!parent!, :$!statement_handle!,
     }
 }
 
-method execute(*@params is raw) {
+method execute(*@params is raw --> DBDish::StatementHandle) {
     self!enter-execute(@params.elems, $!param-count);
 
     my int $num-params = @params.elems;

--- a/lib/DBDish/StatementHandle.pm6
+++ b/lib/DBDish/StatementHandle.pm6
@@ -26,7 +26,7 @@ has @!column-type;
 has $!which = self.WHICH;
 
 # My defined interface
-method execute(*@ --> Int) { ... }
+method execute(*@ --> DBDish::StatementHandle) { ... }
 method finish(--> Bool) { ... }
 method _row(--> Array) { ... }
 method _free() { ... }
@@ -49,7 +49,7 @@ method !done-execute(Int $rows, $fields) {
     $!Finished = False;
     $!affected_rows = $rows;
     self.finish unless $fields;
-    self.rows;
+    self;
 }
 
 method new(*%args) {

--- a/lib/DBDish/mysql/StatementHandle.pm6
+++ b/lib/DBDish/mysql/StatementHandle.pm6
@@ -96,7 +96,7 @@ submethod BUILD(:$!mysql_client!, :$!parent!, :$!stmt = MYSQL_STMT,
     }
 }
 
-method execute(*@params) {
+method execute(*@params --> DBDish::StatementHandle) {
     self!enter-execute(@params.elems, $!param-count);
     if $!stmt { # Prepared
         if $!param-count {
@@ -212,6 +212,7 @@ method _row {
                 $row = True;
             }
         } elsif $row = $!result_set.fetch_row {
+            # TODO: This should support $!parent.Converter.
             $list = do for ^$fields { $row.want($_, @!column-type[$_]) }
             $!affected_rows++ unless $!Prefetch;
         }

--- a/lib/DBIish.pm6
+++ b/lib/DBIish.pm6
@@ -1,7 +1,7 @@
 use v6;
 # DBIish.pm6
 
-unit class DBIish:auth<mberends>:ver<0.6.0>;
+unit class DBIish:auth<mberends>:ver<0.6.1>:api<1>;
     use DBDish;
 
     package GLOBAL::X::DBIish {
@@ -106,11 +106,11 @@ unit class DBIish:auth<mberends>:ver<0.6.0>;
 
     my $dbh = DBIish.connect("SQLite", :database<example-db.sqlite3>);
 
-    my $sth = $dbh.do(q:to/STATEMENT/);
+    my $sth = $dbh.execute(q:to/STATEMENT/);
         DROP TABLE nom
         STATEMENT
 
-    $sth = $dbh.do(q:to/STATEMENT/);
+    $sth = $dbh.execute(q:to/STATEMENT/);
         CREATE TABLE nom (
             name        varchar(4),
             description varchar(30),
@@ -119,7 +119,7 @@ unit class DBIish:auth<mberends>:ver<0.6.0>;
         )
         STATEMENT
 
-    $sth = $dbh.do(q:to/STATEMENT/);
+    $sth = $dbh.execute(q:to/STATEMENT/);
         INSERT INTO nom (name, description, quantity, price)
         VALUES ( 'BUBH', 'Hot beef burrito', 1, 4.95 )
         STATEMENT

--- a/t/20-mysql.t
+++ b/t/20-mysql.t
@@ -118,9 +118,9 @@ try {
     CATCH { die "ERROR: {DBIish.errstr}. Can't continue test\n"; }
 }
 ok($dbh.defined, "Connected to database"); # test 5
-lives-ok({$dbh.do("DROP TABLE IF EXISTS $table")}, "making slate clean"); # test 6
-lives-ok({$dbh.do("CREATE TEMPORARY TABLE $table (id INT(4), name VARCHAR(20))")}, "creating $table"); # test 7
-lives-ok({$dbh.do("DROP TABLE $table")}, "dropping created $table"); # test 8
+lives-ok({$dbh.execute("DROP TABLE IF EXISTS $table")}, "making slate clean"); # test 6
+lives-ok({$dbh.execute("CREATE TEMPORARY TABLE $table (id INT(4), name VARCHAR(20))")}, "creating $table"); # test 7
+lives-ok({$dbh.execute("DROP TABLE $table")}, "dropping created $table"); # test 8
 
 #-----------------------------------------------------------------------
 # from perl5 DBD/mysql/t/25lockunlock.t
@@ -151,11 +151,11 @@ CREATE TEMPORARY TABLE $table (
     name varchar(30) NOT NULL default ''
 )
 ";
-lives-ok { $dbh.do("DROP TABLE IF EXISTS $table") }, "drop table if exists $table"; # test 9
-lives-ok { $dbh.do($create) }, "create table $table"; # test 10
-ok $dbh.do("LOCK TABLES $table WRITE"), "lock tables $table write"; # test 11
-ok $dbh.do("INSERT INTO $table VALUES(1, 'Alligator Descartes test 12')"), "Insert"; # test 12
-lives-ok {$dbh.do("DELETE FROM $table WHERE id = 1") }, "Delete"; # test 13
+lives-ok { $dbh.execute("DROP TABLE IF EXISTS $table") }, "drop table if exists $table"; # test 9
+lives-ok { $dbh.execute($create) }, "create table $table"; # test 10
+ok $dbh.execute("LOCK TABLES $table WRITE"), "lock tables $table write"; # test 11
+ok $dbh.execute("INSERT INTO $table VALUES(1, 'Alligator Descartes test 12')"), "Insert"; # test 12
+lives-ok {$dbh.execute("DELETE FROM $table WHERE id = 1") }, "Delete"; # test 13
 my $sth;
 try {
     $sth= $dbh.prepare("SELECT * FROM $table WHERE id = 1");
@@ -167,8 +167,8 @@ $row = $sth.row();
 $errstr= $sth.errstr;
 nok $row, "Fetch should have failed"; # test 16
 nok $errstr, "Fetch should have failed"; # test 17
-ok $dbh.do("UNLOCK TABLES"), "Unlock tables"; # test 18
-ok $dbh.do("DROP TABLE $table"), "Drop table $table"; # test 19
+ok $dbh.execute("UNLOCK TABLES"), "Unlock tables"; # test 18
+ok $dbh.execute("DROP TABLE $table"), "Drop table $table"; # test 19
 
 #-----------------------------------------------------------------------
 # from perl5 DBD/mysql/t/29warnings.t
@@ -234,13 +234,13 @@ if $dbh.drv.library.name ~~ /mariadb/ {
 #ok $sth2->finish();
 #ok $dbh->do("DROP TABLE $table");
 #ok $dbh->disconnect();
-ok $dbh.do("DROP TABLE IF EXISTS $table"), "drop table if exists $table"; # test 23
+ok $dbh.execute("DROP TABLE IF EXISTS $table"), "drop table if exists $table"; # test 23
 $create = "
 CREATE TEMPORARY TABLE $table (
   id INT(3) PRIMARY KEY AUTO_INCREMENT NOT NULL,
   name VARCHAR(31))
 ";
-ok $dbh.do($create), "create $table"; # test 24
+ok $dbh.execute($create), "create $table"; # test 24
 my $query= "INSERT INTO $table (name) VALUES (?)";
 ok ($sth= $dbh.prepare($query)), "prepare insert with parameter"; # test 25
 ok $sth.execute("Jochen"), "execute insert with parameter"; # test 26
@@ -256,7 +256,7 @@ is $sth.insert-id, $max_id[0], 'sth insert id $sth.insert-id == max(id) $max_id[
 is $dbh.insert-id, $max_id[0], 'dbh insert id $dbh.insert-id == max(id) $max_id[0] in '~$table; # test 35
 ok $sth.finish(), "statement 1 finish"; #  test 36
 ok $sth2.finish(), "statement 2 finish"; # test 37
-ok $dbh.do("DROP TABLE $table"),"drop table $table"; # test 38
+ok $dbh.execute("DROP TABLE $table"),"drop table $table"; # test 38
 # Because the drop table might fail, disconnect and reconnect
 $dbh.dispose();
 try {
@@ -290,13 +290,13 @@ try {
 #ok $sth->finish;
 #ok $dbh->do("DROP TABLE $table");
 #ok $dbh->disconnect();
-ok $dbh.do("DROP TABLE IF EXISTS $table"),"drop table if exists $table"; # test 39
+ok $dbh.execute("DROP TABLE IF EXISTS $table"),"drop table if exists $table"; # test 39
 $create = "
 CREATE TEMPORARY TABLE $table (
     id INT(3) PRIMARY KEY NOT NULL,
     name VARCHAR(32))
 ";
-ok $dbh.do($create), "create $table"; # test 40
+ok $dbh.execute($create), "create $table"; # test 40
 $query = "INSERT INTO $table (id, name) VALUES (?,?)";
 ok ($sth = $dbh.prepare($query)),"prepare $query"; #  test 41
 ok $sth.execute(1, "Jocken"), "execute insert Jocken"; # test 42
@@ -331,8 +331,8 @@ $sth.PrintError = Bool::True;
 #ok(@$array_ref == 50);
 #ok($sth->finish);
 #ok($dbh->do("DROP TABLE $table"));
-ok($dbh.do("DROP TABLE IF EXISTS $table"), "making slate clean"); # test 45
-ok($dbh.do("CREATE TEMPORARY TABLE $table (id INT(4), name VARCHAR(35))"), "creating table"); # test 46
+ok($dbh.execute("DROP TABLE IF EXISTS $table"), "making slate clean"); # test 45
+ok($dbh.execute("CREATE TEMPORARY TABLE $table (id INT(4), name VARCHAR(35))"), "creating table"); # test 46
 ok(($sth = $dbh.prepare("INSERT INTO $table (id,name) VALUES (?,?)")),"prepare insert with 2 params"); # test 47
 my ( %testInsertVals, $all_ok );
 $all_ok = Bool::True;
@@ -410,8 +410,8 @@ is($array_ref.elems, 50,"limit 50 works"); # test 52
 ## Install a handler so that a warning about unfreed resources gets caught
 #$SIG{__WARN__} = sub { die @_ };
 #ok($dbh->disconnect(), "Testing disconnect");
-ok($dbh.do("DROP TABLE IF EXISTS t1"), "35prepare.t Making slate clean"); # test 53
-ok($dbh.do("CREATE TABLE t1 (id INT(4), name VARCHAR(35))"), "Creating table"); # test 54
+ok($dbh.execute("DROP TABLE IF EXISTS t1"), "35prepare.t Making slate clean"); # test 53
+ok($dbh.execute("CREATE TABLE t1 (id INT(4), name VARCHAR(35))"), "Creating table"); # test 54
 ok($sth = $dbh.prepare("SHOW TABLES LIKE 't1'"),"prepare show tables"); # test 55
 ok($sth.execute(), "Executing 'show tables'"); # test 56
 my @row;
@@ -420,10 +420,10 @@ ok((defined(@row = $sth.row()) &&
   "Testing if result set and no errors"); # test 57
 is(@row[0], 't1', "Checking if results equal to 't1'"); # test 58
 ok($sth.finish, "Finishing up with statement handle"); # test 59
-ok($dbh.do("INSERT INTO t1 VALUES (1,'1st first value')"),"Inserting first row"); # test 60
+ok($dbh.execute("INSERT INTO t1 VALUES (1,'1st first value')"),"Inserting first row"); # test 60
 ok($sth= $dbh.prepare("INSERT INTO t1 VALUES (2,'2nd second value')"),"Preparing insert of second row"); # test 61
 my $rows;
-ok(($rows = $sth.execute()), "Inserting second row"); # test 62
+ok(($rows = $sth.execute.rows), "Inserting second row"); # test 62
 is($rows, 1, "One row should have been inserted"); # test 63
 ok($sth.finish, "Finishing up with statement handle"); # test 64
 ok($sth= $dbh.prepare("SELECT id, name FROM t1 WHERE id = 1"),"Testing prepare of query"); # test 65
@@ -519,14 +519,14 @@ ok(!($sth.row()),"Not Fetch - Testing bug #20153"); # test 81
 #ok ($dbh->do("DROP TABLE $table"));
 #ok $sth->finish;
 #ok $dbh->disconnect;
-ok ($dbh.do("DROP TABLE IF EXISTS $table")),"drop table before 40bindparam.t"; # test 82
+ok ($dbh.execute("DROP TABLE IF EXISTS $table")),"drop table before 40bindparam.t"; # test 82
 $create = "
 CREATE TEMPORARY TABLE $table (
         id int(4) NOT NULL default 0,
         name varchar(40) default ''
         )
 ";
-ok ($dbh.do($create)),"create table with defaults"; # test 83
+ok ($dbh.execute($create)),"create table with defaults"; # test 83
 ok ($sth = $dbh.prepare("INSERT INTO $table VALUES (?, ?)")),"prepare parameterized insert"; # test 84
 my $numericVal = 1; # Automatic type detection
 my $charVal = "Alligator Descartes";
@@ -573,14 +573,14 @@ is $dbh.quote('foo'):as-id, '`foo`',    'Quote Id';
 #ok ($dbh->do("DROP TABLE $table"));
 #ok ($dbh->disconnect());
 
-#ok $dbh.do("DROP TABLE IF EXISTS $table"), "drop table $table"; # test 87
+#ok $dbh.execute("DROP TABLE IF EXISTS $table"), "drop table $table"; # test 87
 #$create= "
 #CREATE TABLE $table (
 #    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 #    num INT(3))
 #";
-#ok $dbh.do($create), "create table $table"; # test 88
-#ok $dbh.do("INSERT INTO $table VALUES(NULL, 1)"), "insert into $table (null, 1)"; # test 89
+#ok $dbh.execute($create), "create table $table"; # test 88
+#ok $dbh.execute("INSERT INTO $table VALUES(NULL, 1)"), "insert into $table (null, 1)"; # test 89
 
 
 #-----------------------------------------------------------------------

--- a/t/24-mysql-large-value.t
+++ b/t/24-mysql-large-value.t
@@ -24,7 +24,7 @@ without $dbh {
 
 ok $dbh,    'Connected';
 lives-ok {
-    $dbh.do(qq|
+    $dbh.execute(qq|
     CREATE TEMPORARY TABLE test_long_string (
 	col1 varchar(16383)
     )|)
@@ -44,9 +44,9 @@ for @long-strings -> $string {
 }
 $sth.dispose;
 
-$sth = $dbh.prepare('SELECT col1 FROM test_long_string ORDER BY length(col1)');
+$sth = $dbh.execute('SELECT col1 FROM test_long_string ORDER BY length(col1)');
 
-is $sth.execute, @long-strings.elems, '%d row'.sprintf(@long-strings.elems);
+is $sth.rows, @long-strings.elems, '%d row'.sprintf(@long-strings.elems);
 
 # Compare both source and DB long strings in order by length.
 for @long-strings -> $string {

--- a/t/26-mysql-blob.t
+++ b/t/26-mysql-blob.t
@@ -23,7 +23,7 @@ without $dbh {
 
 ok $dbh,    'Connected';
 lives-ok {
-    $dbh.do(q|
+    $dbh.execute(q|
     CREATE TEMPORARY TABLE test_blob (
 	id INT(3) NOT NULL DEFAULT 0, 
 	name BLOB)|)

--- a/t/27-mysql-datetime.t
+++ b/t/27-mysql-datetime.t
@@ -26,7 +26,7 @@ my $subsec = $dbh.drv.version after v5.6.4;
 my $field = 'TIMESTAMP'; $field ~= '(6)' if $subsec;
 diag "Using $field";
 lives-ok {
-    $dbh.do(qq|
+    $dbh.execute(qq|
     CREATE TEMPORARY TABLE test_datetime (
 	adate DATE,
 	atime TIME,
@@ -45,7 +45,7 @@ $sth = $dbh.prepare('SELECT adate, atimestamp FROM test_datetime');
 my @coltype = $sth.column-types;
 ok @coltype eqv [Date, DateTime],	    'Column-types';
 
-is $sth.execute, 1,			    'One row';
+is $sth.execute.rows, 1,			    'One row';
 my ($date, $datetime) = $sth.row;
 isa-ok $date, Date;
 isa-ok $datetime,  DateTime;
@@ -53,7 +53,7 @@ is $date, $now.Date,			    'Today';
 is $datetime, $now,			    'Right now';
 $sth.dispose;
 $sth = $dbh.prepare('SELECT NOW()');
-is $sth.execute, 1,			    'One now';
+is $sth.execute.rows, 1,			    'One now';
 $datetime = $sth.row[0];
 if $subsec {
     isnt $datetime, $now,		    'Server drift';

--- a/t/34-pg-types.t
+++ b/t/34-pg-types.t
@@ -27,9 +27,9 @@ without $dbh {
 ok $dbh,    'Connected';
 
 # Be less verbose;
-$dbh.do('SET client_min_messages TO WARNING');
+$dbh.execute('SET client_min_messages TO WARNING');
 lives-ok {
-    $dbh.do(q|
+    $dbh.execute(q|
     CREATE TEMPORARY TABLE test_types (
 	col1 text
     )|)
@@ -44,11 +44,14 @@ $sth = $dbh.prepare('SELECT col1 FROM test_types');
 my @coltype = $sth.column-types;
 ok @coltype eqv [Str],	    'Column-types';
 
-is $sth.execute, 1,			    '1 row';
+$sth.execute;
+is $sth.rows, 1,			    '1 row';
 my ($col1) = $sth.row;
 isa-ok $col1, Str;
 is $col1, 'test',			    'Test';
 $dbh.Converter{Str} = sub ($) { 'changed' };
-is $sth.execute, 1,			    '1 row';
+
+$sth.execute;
+is $sth.rows, 1,			    '1 row';
 ($col1) = $sth.row;
 is $col1, 'changed',		    'Changed';

--- a/t/35-pg-common.t
+++ b/t/35-pg-common.t
@@ -12,7 +12,7 @@ DBIish::CommonTesting.new(
     :%opts,
     post_connect_cb => sub {
 	# We want to see some messages
-        $^dbh.do( 'SET client_min_messages = warning' );
+        $^dbh.execute( 'SET client_min_messages = warning' );
     }
 ).run-tests;
 

--- a/t/36-pg-array.t
+++ b/t/36-pg-array.t
@@ -25,7 +25,7 @@ without $dbh {
     exit;
 }
 
-my $sth = $dbh.do(q:to/STATEMENT/);
+my $sth = $dbh.execute(q:to/STATEMENT/);
   CREATE TEMPORARY TABLE sal_emp (
     name               text,
     pay_by_quarter     integer[],
@@ -34,7 +34,7 @@ my $sth = $dbh.do(q:to/STATEMENT/);
   );
 STATEMENT
 
-$sth = $dbh.do(q:to/STATEMENT/);
+$sth = $dbh.execute(q:to/STATEMENT/);
     INSERT INTO sal_emp
     VALUES (
       'Bill',
@@ -180,11 +180,11 @@ STATEMENT
 # Roundtrip a Raku array via do().
 {
     # Array type provided for older version of Pg
-    $dbh.do(q{CREATE TEMPORARY TABLE test_do_array (col1 text[]);});
+    $dbh.execute(q{CREATE TEMPORARY TABLE test_do_array (col1 text[]);});
 
     my @arr = <some array text here>;
 
-    $dbh.do(q{INSERT INTO test_do_array VALUES ($1)}, @arr);
+    $dbh.execute(q{INSERT INTO test_do_array VALUES ($1)}, @arr);
     my $sth = $dbh.prepare(q{SELECT col1 FROM test_do_array});
     $sth.execute();
 

--- a/t/36-pg-blob.t
+++ b/t/36-pg-blob.t
@@ -26,7 +26,7 @@ without $dbh {
 
 ok $dbh,    'Connected';
 lives-ok {
-    $dbh.do(q|
+    $dbh.execute(q|
     CREATE TEMPORARY TABLE test_blob (
 	id INT NOT NULL DEFAULT 0, 
 	name bytea)|)

--- a/t/36-pg-enum.t
+++ b/t/36-pg-enum.t
@@ -30,9 +30,9 @@ without $dbh {
 }
 
 ok $dbh,    'Connected';
-lives-ok { $dbh.do('DROP TYPE IF EXISTS yesno') }, 'Clean';
+lives-ok { $dbh.execute('DROP TYPE IF EXISTS yesno') }, 'Clean';
 lives-ok {
-    $dbh.do(q|
+    $dbh.execute(q|
     CREATE TYPE yesno AS ENUM (
 	'Yes',
 	'No'
@@ -41,7 +41,7 @@ lives-ok {
 
 
 lives-ok {
-    $dbh.do(q|
+    $dbh.execute(q|
     CREATE TEMPORARY TABLE test_enum (
 	id INT NOT NULL DEFAULT 0, 
 	yeah yesno)|)

--- a/t/36-pg-native.t
+++ b/t/36-pg-native.t
@@ -46,11 +46,11 @@ is $row<col1>, 'some string value', 'Basic dollar quoting';
 is $row<col2>, q{another string$$ "value 'here}, 'Named dollar quoting';
 
 # Listen/Notify
-lives-ok { $dbh.do('LISTEN test') }, 'Listen to test';
+lives-ok { $dbh.execute('LISTEN test') }, 'Listen to test';
 my $note = $dbh.pg-notifies;
 isa-ok $note, Any, 'No notification';
-lives-ok { $dbh.do('NOTIFY test') }, 'Notify test';
-lives-ok { $dbh.do("NOTIFY test, 'Payload'") }, 'Notify test w/payload';
+lives-ok { $dbh.execute('NOTIFY test') }, 'Notify test';
+lives-ok { $dbh.execute("NOTIFY test, 'Payload'") }, 'Notify test w/payload';
 $note = $dbh.pg-notifies;
 isa-ok $note, 'DBDish::Pg::Native::pg-notify', 'A notification received';
 is $note.relname, 'test', 'Test channel';

--- a/t/37-pg-datetime.t
+++ b/t/37-pg-datetime.t
@@ -26,10 +26,10 @@ without $dbh {
 
 ok $dbh,    'Connected';
 # Be less verbose;
-$dbh.do('SET client_min_messages TO WARNING');
-$dbh.do('SET timezone TO UTC');
+$dbh.execute('SET client_min_messages TO WARNING');
+$dbh.execute('SET timezone TO UTC');
 lives-ok {
-    $dbh.do(q|
+    $dbh.execute(q|
     CREATE TEMPORARY TABLE test_datetime (
 	adate DATE,
 	atime TIME,
@@ -51,7 +51,8 @@ $sth = $dbh.prepare('SELECT adate, atimestamp FROM test_datetime');
 my @coltype = $sth.column-types;
 ok @coltype eqv [Date, DateTime],	    'Column-types';
 
-is $sth.execute, 2,			    'Two rows';
+$sth.execute;
+is $sth.rows, 2,			    'Two rows';
 my ($date, $datetime) = $sth.row;
 isa-ok $date, Date;
 isa-ok $datetime,  DateTime;
@@ -68,7 +69,6 @@ diag $datetime.Instant - $now.Instant;
 # Pg cannot convert years, months, days to an integer as those vary in length
 # Also note intervalStyle variations.
 my $sthint = $dbh.prepare(q{SELECT INTERVAL '1 century + 1 month - 5 days 4 hours - 32 minutes' AS intexample});
-$sthint.execute();
-my $row = $sthint.row(:hash);
+my $row = $sthint.execute().row(:hash);
 is $row<intexample>, '100 years 1 mon -5 days +03:28:00', 'Complex interval';
 

--- a/t/38-pg-connection-lock.t
+++ b/t/38-pg-connection-lock.t
@@ -45,9 +45,7 @@ await $p1;
 
 # Test for query success
 lives-ok {
-    my $sth-select = $dbh.prepare('SELECT 1 AS value');
-    $sth-select.execute();
-    my $row = $sth-select.row(:hash);
+    my $row = $dbh.execute('SELECT 1 AS value').row(:hash);
     is($row<value>, 1, 'Query returned a result');
 }, 'DB Connection uncorrupted';
 

--- a/t/38-pg-errors.t
+++ b/t/38-pg-errors.t
@@ -38,7 +38,7 @@ if $db-version !~~ /^ '9.'<[3 .. 6]> | 1\d / {
     my $ex;
     my $query = q{SELECT nocolumn FROM pg_class;};
     throws-like {
-        $dbh.do($query);
+        $dbh.execute($query);
 
         CATCH {
             default {
@@ -55,7 +55,7 @@ if $db-version !~~ /^ '9.'<[3 .. 6]> | 1\d / {
             source-line   => / \d+ /,
             source-function => 'errorMissingColumn',
             statement => $query,
-            statement-name => q{},
+            statement-name => / \w+ /,
             dbname => %*ENV<PGDATABASE>,
             host => / \w+ /,
             port => / \d+ /,
@@ -106,7 +106,7 @@ if $db-version !~~ /^ '9.'<[3 .. 6]> | 1\d / {
     _QUERY_
 
     throws-like {
-        $dbh.do($query);
+        $dbh.execute($query);
 
         # Copy needed for additional testing. throws-like cannot handle Bool type
         CATCH {
@@ -133,7 +133,7 @@ if $db-version !~~ /^ '9.'<[3 .. 6]> | 1\d / {
             source-line => / \d+ /,
             source-function => 'exec_stmt_raise',
             statement => $query,
-            statement-name => q{},
+            statement-name => /^ .+ $/,
             dbname => %*ENV<PGDATABASE>,
             host => / \w+ /,
             port => / \d+ /,
@@ -152,8 +152,7 @@ if $db-version !~~ /^ '9.'<[3 .. 6]> | 1\d / {
     _QUERY_
 
     throws-like {
-        my $sth = $dbh.prepare($query);
-        $sth.execute();
+        my $sth = $dbh.execute($query);
         CATCH {
             default {
                 $ex = $_;

--- a/t/43-sqlite-threads.t
+++ b/t/43-sqlite-threads.t
@@ -22,7 +22,7 @@ END try $database.unlink;
 # Create a test table.
 my $dbh = DBIish.connect("SQLite", :$database);
 END try $dbh.dispose;
-$dbh.do('CREATE TABLE nom ( name varchar(50) )');
+$dbh.execute('CREATE TABLE nom ( name varchar(50) )');
 
 
 # Check that it is possible to work with the database from multiple threads
@@ -52,7 +52,7 @@ subtest 'Statements across threads on one connection' => {
         $sth.finish;
     }
 
-    $dbh.do('DELETE FROM nom');
+    $dbh.execute('DELETE FROM nom');
 }
 
 # Check that it is possible to work with the database from multiple threads
@@ -83,5 +83,5 @@ subtest 'Multiple connections, one per thread' => {
         $sth.finish;
     }
 
-    $dbh.do('DELETE FROM nom');
+    $dbh.execute('DELETE FROM nom');
 }

--- a/t/46-sqlite-blob.t
+++ b/t/46-sqlite-blob.t
@@ -24,9 +24,9 @@ without $dbh {
 }
 
 ok $dbh,    'Connected';
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test_blob') }, 'Clean';
+lives-ok { $dbh.execute('DROP TABLE IF EXISTS test_blob') }, 'Clean';
 lives-ok {
-    $dbh.do(q|
+    $dbh.execute(q|
     CREATE TABLE test_blob (
 	id INT NOT NULL DEFAULT 0, 
 	name bytea)|)
@@ -50,6 +50,6 @@ is @res.elems,  1,	 'One field';
 $data = @res[0];
 ok $data ~~ Buf,         'Data is-a Buf';
 ok not $data.defined,    'But is NULL';
-$dbh.do('DROP TABLE IF EXISTS test_blob');
+$dbh.execute('DROP TABLE IF EXISTS test_blob');
 $dbh.dispose;
 $TDB.unlink;

--- a/t/48-sqlite-errors.t
+++ b/t/48-sqlite-errors.t
@@ -25,8 +25,8 @@ ok not $dbh.err,    'Without errors en $dbh';
 ok not DBIish.err,  'Error cleared in DBIish';
 
 lives-ok {
-    $dbh.do('DROP TABLE IF EXISTS with_unique');
-    $dbh.do('CREATE TABLE with_unique(a integer not null, b integer not null, UNIQUE(a, b))');
+    $dbh.execute('DROP TABLE IF EXISTS with_unique');
+    $dbh.execute('CREATE TABLE with_unique(a integer not null, b integer not null, UNIQUE(a, b))');
 }, 'Can create table';
 
 my $insert = $dbh.prepare('INSERT INTO with_unique(a, b) VALUES(?, ?)');

--- a/t/56-oracle-blob.t
+++ b/t/56-oracle-blob.t
@@ -39,9 +39,9 @@ my $dropper = q|
     END;|;
 
 ok $dbh,    'Connected';
-lives-ok { $dbh.do($dropper) }, 'Clean';
+lives-ok { $dbh.execute($dropper) }, 'Clean';
 lives-ok {
-    $dbh.do(q|CREATE TABLE test_blob (id NUMBER, name RAW(300) )|)
+    $dbh.execute(q|CREATE TABLE test_blob (id NUMBER, name RAW(300) )|)
 }, 'Table created';
 my $blob = Buf.new(^256);
 my $query = 'INSERT INTO test_blob VALUES(?, ?)';
@@ -61,4 +61,4 @@ is @res.elems,  1,	 'One field';
 $data = @res[0];
 ok $data ~~ Buf,         'Data is-a Buf';
 ok not $data.defined,    'But is NULL';
-$dbh.do($dropper);
+$dbh.execute($dropper);

--- a/t/57-oracle-datetime.t
+++ b/t/57-oracle-datetime.t
@@ -38,9 +38,9 @@ my $dropper = q|
           END IF;
     END;|;
 
-lives-ok { $dbh.do($dropper) }, 'Clean';
+lives-ok { $dbh.execute($dropper) }, 'Clean';
 lives-ok {
-    $dbh.do(qq|
+    $dbh.execute(qq|
     CREATE TABLE test_datetime (
 	adate DATE,
 	atimestamp TIMESTAMP(6) WITH TIME ZONE
@@ -85,4 +85,4 @@ my $datetime2 = $sth.row[0];
 isnt $datetime, $datetime2,		    'Server drift';
 diag $datetime2.Instant - $datetime.Instant;
 
-$dbh.do($dropper);
+$dbh.execute($dropper);


### PR DESCRIPTION
dbh.execute, unlike dbh.do, returns a statement handle instead of a (sometimes incorrect) row count. This allows for a simple query with parameters to be executed without being prepared first.

I didn't want to change do(), and preferred a bit more naming consistency with sth.execute(). do is removed from documentation but not (yet) deprecated. Feedback is appreciated! 

OLD:
 $dbh.do( 'CREATE TABLE tab (foo text, id int5)' );

 my $sth = $dbh.prepare('SELECT foo FROM tab WHERE id = ?');
 $sth.execute($id);
 for $sth.allrows(:array-of-hash) -> $row {}

NEW:
 $dbh.execute( 'CREATE TABLE tab (foo text, id int5)' );

 for $dbh.execute('SELECT foo FROM tab WHERE id = ?', $id).allrows(:array-of-hash) -> $row {}

$dbh.do still exists but it is now undocumented to discourage use and should become deprecated in the near future. do() did not allow statements which has results which made it rather unhelpful. It's main purpose was to bypass prepare() for statements which broke under prepare() such as LOCK TABLE on MySQL.


$sth.execute previously returned a count of the effected rows. Now, for consistency with $dbh.execute, it returns a statement handle to allow chaining of rows, allrows, etc. directly onto the execute result. Fail/exceptions are far better for error handling than the return code was.


NOTE, MySQL for type conversion (such as the JSON example) still requires going through prepare.execute as the result set is handled differently.

Solves #185.