### PR TITLE
Add support: issues #203, #204, #207

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -659,6 +659,11 @@ be disabled using these options in the connect method.
    :no-alter-session      # don't apply the alter session defaults
    :no-datetime-container # return the date/timestamps as stings
 
+Prior versions of DBDish coerced Oracle field names to lower-case when data is a hash.
+If you still require/want this ability use this option. This option is not recommended.
+
+   :lc-field-names
+
 =head1 TESTING
 
 The C<DBIish::CommonTesting> module, now with over 100 tests, provides a common unit

--- a/README.pod
+++ b/README.pod
@@ -644,6 +644,21 @@ Supports basic CRUD operations and prepared statements with placeholders
 
     my $dbh = DBIish.connect('Oracle', database => 'XE', :user<sysadm>, :password('secret'));
 
+By default connections to Oracle will apply these session alterations in an attempt to
+make the formatted date/timestamp strings compatible with DateTime class and will be
+provided to the consumer as DateTime.new($str).
+
+    ALTER SESSION SET time_zone               = '-00:00'
+    ALTER SESSION SET nls_date_format         = 'YYYY-MM-DD"T"HH24:MI:SS"Z"'
+    ALTER SESSION SET nls_timestamp_format    = 'YYYY-MM-DD"T"HH24:MI:SS.FF"Z"' # updated
+    ALTER SESSION SET nls_timestamp_tz_format = 'YYYY-MM-DD"T"HH24:MI:SS.FF"Z"'
+
+For consumer purists wanting DBIish to stay out of the way, the above behaviors can
+be disabled using these options in the connect method.
+
+   :no-alter-session      # don't apply the alter session defaults
+   :no-datetime-container # return the date/timestamps as stings
+
 =head1 TESTING
 
 The C<DBIish::CommonTesting> module, now with over 100 tests, provides a common unit

--- a/lib/DBDish/Oracle/Connection.pm6
+++ b/lib/DBDish/Oracle/Connection.pm6
@@ -10,7 +10,14 @@ has OCISvcCtx $!svch;
 has OCIError  $!errh;
 has $.AutoCommit is rw;
 has $.in_transaction is rw;
-submethod BUILD(:$!parent!, :$!envh!, :$!svch!, :$!errh!, :$!AutoCommit = 1) { }
+has $.no-alter-session is rw;
+has $.no-datetime-container is rw;
+
+submethod BUILD(:$!parent!, :$!envh!, :$!svch!, :$!errh!
+    , :$!AutoCommit = 1
+    , :$!no-alter-session = False
+    , :$!no-datetime-container = False
+  ) { }
 
 method !handle-err($res) {
     $res ~~ OCIErr ?? self!set-err(+$res, ~$res) !! $res;
@@ -20,23 +27,38 @@ method prepare(Str $statement, :$RaiseError = $!RaiseError, *%attr) {
     my $oracle_statement = DBDish::Oracle::oracle-replace-placeholder($statement);
 
     with self!handle-err: $!svch.StmtPrepare($oracle_statement, :$!errh) -> $stmth {
-	DBDish::Oracle::StatementHandle.new(
-	    :$!svch,
-	    :$!errh,
-	    :$stmth,
-	    :statement($oracle_statement), # Use the oracle ready statement
-	    :$RaiseError,
-	    :parent(self),
-	    |%attr
-	);
+        DBDish::Oracle::StatementHandle.new(
+            :$!svch,
+            :$!errh,
+            :$stmth,
+            :statement($oracle_statement), # Use the oracle ready statement
+            :$RaiseError,
+            :parent(self),
+            |%attr
+        );
     } else { .fail }
 }
 
 method set-defaults {
-    self.execute(
-	q|ALTER SESSION SET nls_timestamp_tz_format='YYYY-MM-DD"T"HH24:MI:SS.FFTZR'|
-    );
-    $!last-sth-id = Nil; # Lie a little.
+    ## Some are not compatible with DateTime if the field is a timestamp(0) ...
+    ## Most will also produce bad dates using DateTime if the clients can/will be using a
+    ##  a TZ not in the set [GMT,UCT,[+-]00:00]
+    ## Perhaps it's safer to stay out of the consumers way.
+    ## But if we must get in their business lets go all the way!
+    if ! $!no-alter-session
+    {
+      for
+        q|ALTER SESSION SET time_zone               = '-00:00'|,
+        q|ALTER SESSION SET nls_date_format         = 'YYYY-MM-DD"T"HH24:MI:SS"Z"'|,
+        q|ALTER SESSION SET nls_timestamp_format    = 'YYYY-MM-DD"T"HH24:MI:SS.FF"Z"'|,
+        q|ALTER SESSION SET nls_timestamp_tz_format = 'YYYY-MM-DD"T"HH24:MI:SS.FF"Z"'|
+        -> $alter-session-stmt
+      {
+      # $*ERR.say: '# ', $alter-session-stmt;
+        self.execute($alter-session-stmt);
+      }
+      $!last-sth-id = Nil; # Lie a little.
+    }
 }
 
 method commit {

--- a/lib/DBDish/Oracle/Connection.pm6
+++ b/lib/DBDish/Oracle/Connection.pm6
@@ -10,11 +10,13 @@ has OCISvcCtx $!svch;
 has OCIError  $!errh;
 has $.AutoCommit is rw;
 has $.in_transaction is rw;
+has $.lc-field-names is rw;
 has $.no-alter-session is rw;
 has $.no-datetime-container is rw;
 
 submethod BUILD(:$!parent!, :$!envh!, :$!svch!, :$!errh!
     , :$!AutoCommit = 1
+    , :$!lc-field-names = False
     , :$!no-alter-session = False
     , :$!no-datetime-container = False
   ) { }

--- a/lib/DBDish/Oracle/Native.pm6
+++ b/lib/DBDish/Oracle/Native.pm6
@@ -87,7 +87,9 @@ constant SQLT_STR               is export = 5;
 constant SQLT_DAT               is export = 12;
 constant SQLT_BIN               is export = 23;
 constant SQLT_CLOB              is export = 112;
+constant SQLT_TIMESTAMP         is export = 187;
 constant SQLT_TIMESTAMP_TZ      is export = 188;
+constant SQLT_TIMESTAMP_LTZ     is export = 232;
 
 constant %sqltype-map is export = {
     +(SQLT_CHR)  => Str,
@@ -96,8 +98,10 @@ constant %sqltype-map is export = {
     +(SQLT_FLT)  => Num,
     +(SQLT_BIN)  => Buf,
     +(SQLT_CLOB) => Str,
-    +(SQLT_TIMESTAMP_TZ) => DateTime,
-    +(SQLT_DAT) => Date,
+    +(SQLT_TIMESTAMP)     => DateTime,
+    +(SQLT_TIMESTAMP_TZ)  => DateTime,
+    +(SQLT_TIMESTAMP_LTZ) => DateTime,
+    +(SQLT_DAT)  => Date,
 };
 
 constant OCISnapshot  is export = Pointer;

--- a/lib/DBDish/Oracle/StatementHandle.pm6
+++ b/lib/DBDish/Oracle/StatementHandle.pm6
@@ -84,7 +84,7 @@ method !get-meta {
                     and self!handle-err($!errh.gen-error).fail;
                 @!out-binds.push:   $bind;
                 @!out-buffs.push:   $buff;
-                @!column-name.push: $col_name.decode.lc;
+                @!column-name.push: $col_name.decode;
                 warn "No map defined for Oracle type $dtype at column $col\n"
                     unless %sqltype-map{$dtype}:exists;
                 @!column-type.push: %sqltype-map{$dtype};

--- a/lib/DBDish/Oracle/StatementHandle.pm6
+++ b/lib/DBDish/Oracle/StatementHandle.pm6
@@ -84,7 +84,7 @@ method !get-meta {
                     and self!handle-err($!errh.gen-error).fail;
                 @!out-binds.push:   $bind;
                 @!out-buffs.push:   $buff;
-                @!column-name.push: $col_name.decode;
+                @!column-name.push: $!parent.lc-field-names ?? $col_name.decode.lc !! $col_name.decode;
                 warn "No map defined for Oracle type $dtype at column $col\n"
                     unless %sqltype-map{$dtype}:exists;
                 @!column-type.push: %sqltype-map{$dtype};


### PR DESCRIPTION
 - for missing Oracle datatypes
 - updated default alter-session set to be more complete
 - option to turn off builtin alter session default
 - option to turn off date/time wrapping as DateTime object
 - Updated README.pod with additional tips/hints about the Oracle
   support that pre-existed and newly added
 - removed .lc of field names; this is Oracle, best practice is don't second guess, pass on to consumer what you get from Oracle (it's now optional as a switch :lc-field-names)