### PR TITLE
Issue #204 - Support (Oracle) missing types added

### DIFF
--- a/lib/DBDish/Oracle/Native.pm6
+++ b/lib/DBDish/Oracle/Native.pm6
@@ -87,17 +87,21 @@ constant SQLT_STR               is export = 5;
 constant SQLT_DAT               is export = 12;
 constant SQLT_BIN               is export = 23;
 constant SQLT_CLOB              is export = 112;
+constant SQLT_TIMESTAMP         is export = 187;
 constant SQLT_TIMESTAMP_TZ      is export = 188;
+constant SQLT_TIMESTAMP_LTZ     is export = 232;
 
 constant %sqltype-map is export = {
     +(SQLT_CHR)  => Str,
     +(SQLT_NUM)  => Rat,
     +(SQLT_INT)  => Int,
     +(SQLT_FLT)  => Num,
+    +(SQLT_DAT)  => Date,
     +(SQLT_BIN)  => Buf,
     +(SQLT_CLOB) => Str,
-    +(SQLT_TIMESTAMP_TZ) => DateTime,
-    +(SQLT_DAT) => Date,
+    +(SQLT_TIMESTAMP)     => DateTime,
+    +(SQLT_TIMESTAMP_TZ)  => DateTime,
+    +(SQLT_TIMESTAMP_LTZ) => DateTime,
 };
 
 constant OCISnapshot  is export = Pointer;

--- a/lib/DBDish/Oracle/StatementHandle.pm6
+++ b/lib/DBDish/Oracle/StatementHandle.pm6
@@ -72,7 +72,9 @@ method !get-meta {
                     when SQLT_INT { $wtype = $_; Buf[int64].new(0); }
                     when SQLT_BIN { $wtype = $_; proceed; }
                     when SQLT_DAT { $wtype = $_; proceed; }
-                    when SQLT_TIMESTAMP_TZ { $datalen = 50; proceed; }
+                    when SQLT_TIMESTAMP     { $datalen = 50; proceed; }
+                    when SQLT_TIMESTAMP_TZ  { $datalen = 50; proceed; }
+                    when SQLT_TIMESTAMP_LTZ { $datalen = 50; proceed; }
                     default { blob-allocate(Buf, $datalen); }
                 }
                 my $bind = OCIDefine.new;

--- a/t/57-oracle-datetime.t
+++ b/t/57-oracle-datetime.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 use DBIish;
 
-plan 13;
+plan 33;
 
 # Convert to TEMPORARY table instead?
 without %*ENV<DBIISH_WRITE_TEST> {
@@ -14,13 +14,13 @@ my %con-parms = :database<XE>, :username<TESTUSER>, :password<Testpass>;
 my $dbh;
 
 try {
-  $dbh = DBIish.connect('Oracle', |%con-parms);
-  CATCH {
-	    when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
-		diag "$_\nCan't continue.";
-	    }
-            default { .rethrow; }
-  }
+    $dbh = DBIish.connect('Oracle', |%con-parms);
+    CATCH {
+        when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+            diag "$_\nCan't continue.";
+        }
+        default { .rethrow; }
+    }
 }
 without $dbh {
     skip-rest 'prerequisites failed';
@@ -30,7 +30,9 @@ without $dbh {
 ok $dbh,    'Connected';
 my $dropper = q|
     BEGIN
-       EXECUTE IMMEDIATE 'DROP TABLE test_datetime';
+    -- Saved for a rainy day -or- spring cleaning
+    -- EXECUTE IMMEDIATE 'PURGE RECYCLEBIN';
+       EXECUTE IMMEDIATE 'DROP TABLE test_datetime CASCADE CONSTRAINTS PURGE';
     EXCEPTION
        WHEN OTHERS THEN
           IF SQLCODE != -942 THEN
@@ -42,47 +44,120 @@ lives-ok { $dbh.execute($dropper) }, 'Clean';
 lives-ok {
     $dbh.execute(qq|
     CREATE TABLE test_datetime (
-	adate DATE,
-	atimestamp TIMESTAMP(6) WITH TIME ZONE
+        adate DATE,
+        atimestamp0    TIMESTAMP(0),
+        atimestamp6    TIMESTAMP(6),
+        atimestamp0tz  TIMESTAMP(0) WITH TIME ZONE,
+        atimestamp6tz  TIMESTAMP(6) WITH TIME ZONE,
+        atimestamp0ltz TIMESTAMP(0) WITH LOCAL TIME ZONE,
+        atimestamp6ltz TIMESTAMP(6) WITH LOCAL TIME ZONE
     )|);
 }, 'Table created';
 
 my $sth = $dbh.prepare(
-    q|INSERT INTO test_datetime (adate, atimestamp) VALUES(?, ?)|);
+    q|INSERT INTO test_datetime (adate, atimestamp6tz) VALUES(?,?)|);
 my $now = DateTime.now;
 
 lives-ok {
     $sth.execute(
-	$now.Date, # Need a date
-	$now,
+        $now.Date, # Need a date
+        $now,
     );
-},                                           'Can insert Perl6 values';
+},                                           'Can insert Raku values';
 $sth.dispose;
 
-$sth = $dbh.prepare('SELECT adate, atimestamp FROM test_datetime');
+$sth = $dbh.prepare('SELECT adate, atimestamp6tz FROM test_datetime');
 my @coltype = $sth.column-types;
-ok @coltype eqv [Date, DateTime],	    'Column-types match';
+ok @coltype eqv [Date, DateTime],            'Column-types match';
 
 $sth.execute;
 my ($date, $datetime) = $sth.row;
 isa-ok $date, Date;
 isa-ok $datetime,  DateTime;
 
-is $date, $now.Date,			    'Today';
-is $datetime, $now,			    'Right now';
+is $date, $now.Date,                        'Today';
+is $datetime, $now,                         'Right now';
 $sth.dispose;
 
 $sth = $dbh.prepare('SELECT SYSDATE FROM dual');
 isa-ok $sth.column-types[0], Date, 'SYSDATE is Date';
 $sth.execute;
-is $sth.row[0], Date.today,		    'Today';
+is $sth.row[0], Date.today,                 'Today';
 $sth.dispose;
 
 $sth = $dbh.prepare('SELECT CURRENT_TIMESTAMP FROM dual');
 isa-ok $sth.column-types[0], DateTime, 'CURRENT_TIMESTAMP is DateTime';
 $sth.execute;
 my $datetime2 = $sth.row[0];
-isnt $datetime, $datetime2,		    'Server drift';
+isnt $datetime, $datetime2,                 'Server drift';
+
 diag $datetime2.Instant - $datetime.Instant;
 
-$dbh.execute($dropper);
+ok $dbh.execute('DELETE FROM test_datetime WHERE adate IS NOT NULL'), 'Delete rows';
+ok $dbh.dispose, 'Close session';
+
+note '#+ -------------------------------------------------------- +';
+note '## Issue #204 - ADD Missing TIMESTAMP Support tests (BEGIN)';
+note '#+ -------------------------------------------------------- +';
+
+%con-parms = :database<XE>, :username<TESTUSER>, :password<Testpass>, :!AutoCommit;
+
+try {
+  $dbh = DBIish.connect('Oracle', |%con-parms);
+  CATCH {
+      when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+          diag "$_\nCan't continue.";
+      }
+      default { .rethrow; }
+  }
+}
+
+# session mgmt comming soon
+is $dbh.do('ALTER SESSION SET time_zone               = \'-00:00\''), 0, 'ALTER SESSION ...';
+is $dbh.do('ALTER SESSION SET nls_date_format         = \'YYYY-MM-DD"T"HH24:MI:SS"Z"\''), 0, 'ALTER SESSION ...';
+is $dbh.do('ALTER SESSION SET nls_timestamp_format    = \'YYYY-MM-DD"T"HH24:MI:SS"Z"\''), 0, 'ALTER SESSION ...';
+is $dbh.do('ALTER SESSION SET nls_timestamp_tz_format = \'YYYY-MM-DD"T"HH24:MI:SS"Z"\''), 0, 'ALTER SESSION ...';
+is $dbh.execute('SELECT * FROM test_datetime').allrows, (), 'Perfect table is empty!';
+
+$sth = $dbh.prepare(
+    q|INSERT INTO test_datetime
+    FIELDS (adate, atimestamp0, atimestamp6, atimestamp0tz, atimestamp6tz, atimestamp0ltz, atimestamp6ltz)
+    VALUES (?,?,?,?,?,?,?)|);
+$now = DateTime.now.truncated-to('second').in-timezone(0);
+
+say '# Tasty timestamp: ', $now;
+lives-ok {
+    $sth.execute(
+        $now, # Need an ISO full date
+        $now, $now, $now, $now, $now, $now
+    );
+},                                           'Can insert Raku values';
+
+is $dbh.execute('SELECT * FROM test_datetime').allrows.elems, 1, 'One row!';
+
+# DATE
+is $dbh.execute('SELECT adate FROM test_datetime').allrows, $now.Date.Str, 'DATE is read into Date.new() but lacks the time component!';
+# TIMESTAMP(0)/(N)
+is $dbh.execute('SELECT atimestamp0 FROM test_datetime').allrows, $now.Str, 'TIMESTAMP(0) is read into DateTime.new()';
+is $dbh.execute('SELECT atimestamp6 FROM test_datetime').allrows, $now.Str, 'TIMESTAMP(6) is read into DateTime.new()';
+# TIMESTAMP(0)/(N) WITH TIME ZONE
+is $dbh.execute('SELECT atimestamp0tz FROM test_datetime').allrows, $now.Str, 'TIMESTAMP(0) W TZ is read into DateTime.new()';
+is $dbh.execute('SELECT atimestamp6tz FROM test_datetime').allrows, $now.Str, 'TIMESTAMP(6) W TZ is read into DateTime.new()';
+# TIMESTAMP(0)/(N) WITH LOCAL TIME ZONE
+is $dbh.execute('SELECT atimestamp0ltz FROM test_datetime').allrows, $now.Str, 'TIMESTAMP(0) W LTZ is read into DateTime.new()';
+is $dbh.execute('SELECT atimestamp6ltz FROM test_datetime').allrows, $now.Str, 'TIMESTAMP(6) W LTZ is read into DateTime.new()';
+
+$dbh.rollback;
+ok $sth.dispose,  'dispose';
+is $dbh.execute('SELECT * FROM test_datetime').allrows.elems, 0, 'Perfect table is empty!';
+
+note '#+ -------------------------------------------------------- +';
+note '## Issue #204 - ADD Missing TIMESTAMP Support tests (END)';
+note '#+ -------------------------------------------------------- +';
+
+# Done
+ok $dbh.execute($dropper), 'Table Cleanup';
+ok $dbh.dispose, 'Say good night!';
+
+# vim: ft=perl6 expandtab
+## END


### PR DESCRIPTION
- SQLT_TIMESTAMP(TIMESTAMP)
- SQLT_TIMESTAMP_LTZ(TIMESTAMP WITH LOCAL TIME ZONE)

As requested one issue, one change set. This should be small and simple enough to pull. The only change in behavior is DBIish will no longer complain and throw exception for about two missing types of TIMESTAMP.
