### PR TITLE
Look up mariadb lib

### DIFF
--- a/lib/DBDish.pm6
+++ b/lib/DBDish.pm6
@@ -57,7 +57,7 @@ role TypeConverter does Associative {
             }
         } else { # Common case
             if (Str.can($type.^name)) {
-                sub ($datum) { $type($datum) };
+                sub ($datum) { try $type($datum) };
             } else {
                 sub ($datum) { $type.new($datum) };
             }

--- a/lib/DBDish/mysql.pm6
+++ b/lib/DBDish/mysql.pm6
@@ -35,6 +35,7 @@ method connect(Str :$host = 'localhost', Int :$port = 3306, Str :$database = 'my
 my $wks = 'mysql_init'; # A well known symbol
 method new() {
     with (%*ENV<DBIISH_MYSQL_LIB> andthen NativeLibs::Searcher.try-versions($_, $wks,0..99))
+    //   NativeLibs::Searcher.try-versions('mariadb', $wks, 0..4)
     //   NativeLibs::Searcher.try-versions('mysqlclient', $wks, 16..21)
     {
         %_<library> = NativeLibs::Loader.load($_);


### PR DESCRIPTION
Makes it look for mariadb lib before it looks for mysql lib, rendering
extra configuration unnecessary in recent versions of Debian/Ubuntu