### PR TITLE
Eliminate error when integer field was null

### DIFF
--- a/lib/DBDish.pm6
+++ b/lib/DBDish.pm6
@@ -57,7 +57,7 @@ role TypeConverter does Associative {
             }
         } else { # Common case
             if (Str.can($type.^name)) {
-                sub ($datum) { $type($datum) };
+                sub ($datum) { try $type($datum) };
             } else {
                 sub ($datum) { $type.new($datum) };
             }


### PR DESCRIPTION
In practical use with mariadb 10.1, sometimes the field of type integer
came to the converter function as null (Str) and the expression

  $type($datum)

where $type === Int and $datum === Str raised an exception. This fixes
the problem.