### PR TITLE
Solve problems with NULL columns

### DIFF
--- a/lib/DBDish/mysql/Native.pm6
+++ b/lib/DBDish/mysql/Native.pm6
@@ -114,11 +114,13 @@ class MyRow does Positional is export {
         if $t ~~ Blob {
             self.blob($idx, $t);
         } else {
-            self[$idx];
+            self[$idx] // $t;
         }
     }
     method blob(Int $idx, Mu $type) {
-        blob-from-pointer($!car[$idx], :elems($!lon[$idx]), :$type);
+        with $!car[$idx] {
+            blob-from-pointer($!car[$idx], :elems($!lon[$idx]), :$type);
+        } else { Str }
     }
 }
 


### PR DESCRIPTION
**The return of the null-blob problem**

This commit solves the problem of trying to retrieve a `Blob` or an `Int` from a MySQL/MariaDB database that has `NULL` on it.

I made a minimal example in the github gist [here](https://gist.github.com/massa/6507d1fecb435abb0a397c935b5b2871)

The example blows with the following error when there is a null `Blob`: 
```
 Parameter 'ptr' of routine 'blob-from-pointer' must be an object
 instance of type 'NativeCall::Types::Pointer', not a type object of type
 'NativeCall::Types::Pointer'.  Did you forget a '.new'?
```

And the following one when there is a null `Int`:
```
 Invocant of method 'Int' must be an object instance of type 'Str', not
 a type object of type 'Str'.  Did you forget a '.new'?
 ```
